### PR TITLE
Trying to fix the compilation error occuring on Rustc Nightly 2018-07-07.

### DIFF
--- a/may_queue/src/lib.rs
+++ b/may_queue/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(nightly, feature(alloc))]
 #![cfg_attr(nightly, feature(core_intrinsics))]
+#![cfg_attr(nightly, feature(raw_vec_internals))]
 #![cfg_attr(all(nightly, test), feature(test))]
 
 mod block_node;


### PR DESCRIPTION
I've tried to test this with
```
[patch.'https://github.com/Xudong-Huang/may.git']
may = {git = "https://github.com/ArtemGr/may", branch = "nightly-2018-07-07"}
```
but unfortunately the `patch` wouldn't work, saying
```
error: failed to select a version for `may`.
versions that meet the requirements `= 0.3.0` are: 0.3.0
```