### PR TITLE
(feat) Adds go_with macro to support creating coroutine with options

### DIFF
--- a/src/io/sys/unix/epoll.rs
+++ b/src/io/sys/unix/epoll.rs
@@ -156,7 +156,10 @@ impl Selector {
     #[inline]
     pub fn add_fd(&self, io_data: IoData) -> io::Result<IoData> {
         let mut info = EpollEvent::new(
-            EpollFlags::EPOLLIN | EpollFlags::EPOLLOUT | EpollFlags::EPOLLRDHUP | EpollFlags::EPOLLET,
+            EpollFlags::EPOLLIN
+                | EpollFlags::EPOLLOUT
+                | EpollFlags::EPOLLRDHUP
+                | EpollFlags::EPOLLET,
             io_data.as_ref() as *const _ as _,
         );
 


### PR DESCRIPTION
Fix #40 

Introduce a `go_with!` macro that supports creating coroutine with options such as name and stack_size. There is a unit test in `tests/lib.rs`:

```rust
    go_with!(8192, move || {
        tx1.send(coroutine::current().stack_size()).unwrap();
    })
    .unwrap()
    .join()
    .unwrap();

    go_with!("test_task", 3i32, move || {
        let task = coroutine::current();
        let msg = (
            task.name().to_owned().map(std::borrow::ToOwned::to_owned),
            task.stack_size(),
        );
        tx2.send(msg).unwrap();
    })
    .unwrap()
    .join()
    .unwrap();
```