### PR TITLE
add aarch64 macOS support to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ May is a high-performance library for programming stackful coroutines with which
 * All the coroutine API are compatible with the standard library semantics;
 * All the coroutine API can be safely called in multi-threaded context;
 * Both stable, beta, and nightly channels are supported;
-* x86_64 GNU/Linux, x86_64 Windows, x86_64 Mac, AArch64 Linux OS are supported.
+* x86_64 GNU/Linux, x86_64 Windows, x86_64 macOS, AArch64 GNU/Linux, and AArch64 macOS are supported.
 
 ----------
 


### PR DESCRIPTION
I wanted to add support for macOS on aarch64, but after building and running the tests, I saw that it seems to be already supported.

Therefore, I have added `aarch64 macOS` as a supported platform to the README

<details>
  <summary>`cargo test` results</summary>

```
~/github/may_deps/may [master]
% cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.05s
     Running unittests src/lib.rs (target/debug/deps/may-f308b4516a58eb36)

running 210 tests
test os::unix::net::test::abstract_namespace_not_allowed ... ok
test os::unix::net::test::long_path ... ok
test io::sys::co_io::tests::compile_co_io ... ok
test os::unix::net::test::test_unix_datagram_recv ... ok
test os::unix::net::test::datagram_pair ... ok
test os::unix::net::test::test_unix_datagram ... ok
test os::unix::net::test::pair ... ok
test os::unix::net::test::test_connect_unix_datagram ... ok
test os::unix::net::test::iter ... ok
test os::unix::net::test::basic ... ok
test os::unix::net::test::test_unnamed_unix_datagram ... ok
test os::unix::net::test::timeouts ... ok
test sync::condvar::tests::smoke ... ok
test sync::condvar::tests::notify_one ... ok
test os::unix::net::test::try_clone ... ok
test sync::mpmc::tests::drop_full ... ok
test sync::mpmc::tests::chan_gone_concurrent ... ok
test sync::mpmc::tests::drop_full_shared ... ok
test sync::condvar::tests::two_mutex - should panic ... ok
test sync::condvar::tests::notify_all ... ok
test sync::condvar::tests::test_condvar_canceled ... ok
test sync::mpmc::tests::no_runtime ... ok
test sync::mpmc::tests::oneshot_multi_task_recv_then_send ... ok
test sync::mpmc::tests::oneshot_multi_thread_close_stress ... ok
test sync::mpmc::tests::oneshot_multi_task_recv_then_close ... ok
test sync::mpmc::tests::oneshot_multi_thread_recv_close_stress ... ok
test sync::mpmc::tests::oneshot_single_thread_close_chan_first ... ok
test sync::mpmc::tests::oneshot_single_thread_close_port_first ... ok
test sync::mpmc::tests::oneshot_multi_thread_send_recv_stress ... ok
test sync::mpmc::tests::oneshot_multi_thread_send_close_stress ... ok
test sync::mpmc::tests::oneshot_single_thread_peek_close ... ok
test sync::mpmc::tests::oneshot_single_thread_peek_data ... ok
test sync::mpmc::tests::oneshot_single_thread_peek_open ... ok
test sync::mpmc::tests::oneshot_single_thread_send_port_close ... ok
test sync::mpmc::tests::oneshot_single_thread_recv_chan_close ... ok
test sync::mpmc::tests::oneshot_single_thread_send_then_recv ... ok
test sync::mpmc::tests::oneshot_single_thread_try_recv_closed ... ok
test sync::mpmc::tests::oneshot_single_thread_try_recv_open ... ok
test sync::mpmc::tests::oneshot_single_thread_try_send_closed ... ok
test sync::mpmc::tests::oneshot_single_thread_try_send_open ... ok
test sync::mpmc::tests::port_gone_concurrent ... ok
test sync::mpmc::tests::port_gone_concurrent1 ... ok
test sync::mpmc::tests::port_gone_concurrent_shared ... ok
test sync::mpmc::tests::recv_from_outside_runtime ... ok
test sync::mpmc::tests::send_from_outside_runtime ... ok
test sync::condvar::tests::wait_timeout ... ok
test sync::mpmc::tests::smoke ... ok
test sync::mpmc::tests::smoke_chan_gone ... ok
test sync::mpmc::tests::smoke_chan_gone_shared ... ok
test sync::mpmc::tests::smoke_coroutine ... ok
test sync::mpmc::tests::smoke_port_gone ... ok
test sync::mpmc::tests::smoke_shared ... ok
test sync::mpmc::tests::smoke_shared_port_gone2 ... ok
test sync::mpmc::tests::smoke_threads ... ok
test sync::mpmc::tests::stream_send_recv_stress ... ok
test sync::mpmc::tests::oneshot_single_thread_recv_timeout ... ok
test sync::mpmc::tests::stress_multi_recv ... ok
test sync::mpmc::tests::recv_timeout_upgrade ... ok
test sync::mpmc::tests::shared_recv_timeout ... ok
test sync::mpmc::tests::recv_a_lot ... ok
test sync::mpmc::tests::test_recv_into_iter_borrowed ... ok
test sync::mpmc::tests::stress ... ok
test sync::mpmc::tests::shared_chan_stress ... ok
test sync::mpmc::tests::test_nested_recv_iter ... ok
test sync::mpmc::tests::test_recv_into_iter_owned ... ok
test sync::mpmc::tests::test_recv_iter_break ... ok
test sync::mpmc::tests::try_recv_states ... ok
test sync::mpsc::tests::chan_gone_concurrent ... ok
test sync::mpsc::tests::drop_full ... ok
test sync::mpsc::tests::drop_full_shared ... ok
test sync::mpmc::tests::test_recv_try_iter ... ok
test sync::mpsc::tests::oneshot_multi_task_recv_then_send ... ok
test sync::mpsc::tests::oneshot_multi_task_recv_then_close ... ok
test sync::mpsc::tests::oneshot_multi_thread_close_stress ... ok
test sync::mpsc::tests::oneshot_multi_thread_recv_close_stress ... ok
test sync::mpsc::tests::oneshot_multi_thread_send_close_stress ... ok
test sync::mpsc::tests::oneshot_multi_thread_send_recv_stress ... ok
test sync::mpsc::tests::oneshot_single_thread_close_chan_first ... ok
test sync::mpsc::tests::oneshot_single_thread_close_port_first ... ok
test sync::mpsc::tests::oneshot_single_thread_peek_close ... ok
test sync::mpsc::tests::oneshot_single_thread_peek_data ... ok
test sync::mpsc::tests::oneshot_single_thread_peek_open ... ok
test sync::mpsc::tests::oneshot_single_thread_recv_timeout ... ok
test sync::mpsc::tests::oneshot_single_thread_send_port_close ... ok
test sync::mpsc::tests::oneshot_single_thread_send_then_recv ... ok
test sync::mpsc::tests::oneshot_single_thread_try_recv_closed ... ok
test sync::mpsc::tests::oneshot_single_thread_try_recv_open ... ok
test sync::mpsc::tests::oneshot_single_thread_try_send_closed ... ok
test sync::mpsc::tests::oneshot_single_thread_try_send_open ... ok
test sync::mpsc::tests::port_gone_concurrent ... ok
test sync::mpsc::tests::port_gone_concurrent1 ... ok
test sync::mpsc::tests::port_gone_concurrent_shared ... ok
test sync::mpsc::tests::recv_a_lot ... ok
test sync::mpsc::tests::recv_from_outside_runtime ... ok
test sync::mpsc::tests::recv_timeout_upgrade ... ok
test sync::mpsc::tests::send_from_outside_runtime ... ok
test sync::mpsc::tests::no_runtime ... ok
test sync::mpsc::tests::shared_chan_stress ... ok
test sync::mpsc::tests::smoke ... ok
test sync::mpsc::tests::smoke_chan_gone ... ok
test sync::mpsc::tests::smoke_chan_gone_shared ... ok
test sync::mpmc::tests::destroy_upgraded_shared_port_when_sender_still_active ... ok
test sync::mpsc::tests::shared_recv_timeout ... ok
test sync::mpsc::tests::smoke_shared ... ok
test sync::mpsc::tests::smoke_port_gone ... ok
test sync::mpsc::tests::smoke_shared_port_gone2 ... ok
test sync::mpsc::tests::stream_send_recv_stress ... ok
test sync::mpsc::tests::smoke_threads ... ok
test sync::mpsc::tests::smoke_coroutine ... ok
test sync::mpsc::tests::oneshot_single_thread_recv_chan_close ... ok
test sync::mpsc::tests::stress ... ok
test sync::mpmc::tests::stress_shared ... ok
test sync::mpsc::tests::test_recv_into_iter_borrowed ... ok
test sync::mpsc::tests::test_nested_recv_iter ... ok
test sync::mpsc::tests::test_recv_into_iter_owned ... ok
test sync::mpsc::tests::test_recv_iter_break ... ok
test sync::mpsc::tests::test_recv_try_iter ... ok
test sync::mpsc::tests::try_recv_states ... ok
test sync::mutex::tests::smoke ... ok
test sync::mutex::tests::test_arc_condvar_poison ... ok
test sync::mutex::tests::test_get_mut ... ok
test sync::mutex::tests::test_get_mut_poison ... ok
test sync::mutex::tests::test_into_inner ... ok
test sync::mutex::tests::test_into_inner_drop ... ok
test sync::mutex::tests::test_into_inner_poison ... ok
test sync::mutex::tests::test_mutex_arc_access_in_unwind ... ok
test sync::mutex::tests::test_mutex_arc_condvar ... ok
test sync::mpsc::tests::destroy_upgraded_shared_port_when_sender_still_active ... ok
test sync::mutex::tests::test_mutex_arc_nested ... ok
test sync::mutex::tests::test_mutex_arc_poison ... ok
test sync::mpsc::tests::stress_shared ... ok
test sync::mutex::tests::test_mutex_unsized ... ok
test sync::mutex::tests::try_lock ... ok
test sync::mutex::tests::lots_and_lots ... ok
test sync::rwlock::tests::smoke ... ok
test sync::rwlock::tests::test_get_mut ... ok
test sync::rwlock::tests::test_get_mut_poison ... ok
test sync::rwlock::tests::test_into_inner ... ok
test sync::rwlock::tests::test_into_inner_drop ... ok
test sync::rwlock::tests::test_into_inner_poison ... ok
test sync::rwlock::tests::test_rw_arc ... ok
test sync::rwlock::tests::test_rw_arc_access_in_unwind ... ok
test sync::rwlock::tests::test_rw_arc_no_poison_rr ... ok
test sync::rwlock::tests::test_rw_arc_no_poison_rw ... ok
test sync::rwlock::tests::test_rw_arc_poison_wr ... ok
test sync::rwlock::tests::test_rw_arc_poison_ww ... ok
test sync::rwlock::tests::test_rwlock_read_canceled ... ok
test sync::rwlock::tests::test_rwlock_try_write ... ok
test sync::rwlock::tests::test_rwlock_unsized ... ok
test sync::rwlock::tests::test_rwlock_write_canceled ... ok
test sync::semphore::tests::sanity_1 ... ok
test sync::semphore::tests::sanity_2 ... ok
test sync::rwlock::tests::frob ... ok
test sync::mutex::tests::test_mutex_canceled ... ok
test sync::mpmc::tests::stress_recv_timeout_two_threads ... ok
test sync::spsc::tests::chan_gone_concurrent ... ok
test sync::spsc::tests::destroy_upgraded_shared_port_when_sender_still_active ... ok
test sync::spsc::tests::drop_full ... ok
test sync::spsc::tests::drop_full_shared ... ok
test sync::spsc::tests::no_runtime ... ok
test sync::spsc::tests::oneshot_multi_task_recv_then_close ... ok
test sync::spsc::tests::oneshot_multi_task_recv_then_send ... ok
test sync::spsc::tests::oneshot_multi_thread_close_stress ... ok
test sync::spsc::tests::oneshot_multi_thread_recv_close_stress ... ok
test sync::spsc::tests::oneshot_multi_thread_send_close_stress ... ok
test sync::spsc::tests::oneshot_multi_thread_send_recv_stress ... ok
test sync::spsc::tests::oneshot_single_thread_close_chan_first ... ok
test sync::spsc::tests::oneshot_single_thread_close_port_first ... ok
test sync::spsc::tests::oneshot_single_thread_peek_close ... ok
test sync::spsc::tests::oneshot_single_thread_peek_data ... ok
test sync::spsc::tests::oneshot_single_thread_peek_open ... ok
test sync::spsc::tests::oneshot_single_thread_recv_chan_close ... ok
test sync::spsc::tests::oneshot_single_thread_send_port_close ... ok
test sync::spsc::tests::oneshot_single_thread_send_then_recv ... ok
test sync::spsc::tests::oneshot_single_thread_try_recv_closed ... ok
test sync::spsc::tests::oneshot_single_thread_try_recv_open ... ok
test sync::spsc::tests::oneshot_single_thread_try_send_closed ... ok
test sync::spsc::tests::oneshot_single_thread_try_send_open ... ok
test sync::spsc::tests::port_gone_concurrent ... ok
test sync::spsc::tests::port_gone_concurrent1 ... ok
test sync::spsc::tests::recv_a_lot ... ok
test sync::spsc::tests::recv_from_outside_runtime ... ok
test sync::spsc::tests::send_from_outside_runtime ... ok
test sync::spsc::tests::smoke ... ok
test sync::spsc::tests::smoke_chan_gone ... ok
test sync::spsc::tests::smoke_coroutine ... ok
test sync::spsc::tests::smoke_port_gone ... ok
test sync::spsc::tests::smoke_threads ... ok
test sync::spsc::tests::stream_send_recv_stress ... ok
test sync::spsc::tests::stress ... ok
test sync::spsc::tests::test_nested_recv_iter ... ok
test sync::spsc::tests::test_recv_into_iter_borrowed ... ok
test sync::spsc::tests::test_recv_into_iter_owned ... ok
test sync::spsc::tests::test_recv_iter_break ... ok
test sync::spsc::tests::test_recv_try_iter ... ok
test sync::spsc::tests::try_recv_states ... ok
test sync::sync_flag::tests::sanity_test ... ok
test sync::mpsc::tests::stress_recv_timeout_two_threads ... ok
test sync::semphore::tests::test_semphore_canceled ... ok
test sync::semphore::tests::test_semphore_co_timeout ... ok
test sync::mutex::tests::test_mutex_canceled_by_other_wait ... ok
test sync::semphore::tests::test_semphore_thread_timeout ... ok
test sync::sync_flag::tests::test_syncflag_co_timeout ... ok
test sync::sync_flag::tests::test_syncflag_thread_timeout ... ok
test sync::sync_flag::tests::test_syncflag_canceled ... ok
test os::unix::net::test::test_read_with_timeout ... ok
test os::unix::net::test::test_read_timeout ... ok
test sync::mpmc::tests::stress_recv_timeout_shared ... ok
test sync::mpsc::tests::stress_recv_timeout_shared ... ok
test timeout_list::tests::test_timeout_list ... ok

test result: ok. 210 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.80s

     Running tests/cqueue.rs (target/debug/deps/cqueue-41643c9fb0b6797d)

running 9 tests
test cqueue_oneshot ... ok
test cqueue_panic_in_select - should panic ... ok
test cqueue_poll ... ok
test cqueue_in_coroutine ... ok
test cqueue_timeout ... ok
test cqueue_drop ... ok
test cqueue_select ... ok
test cqueue_panic - should panic ... ok
test cqueue_loop ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s

     Running tests/lib.rs (target/debug/deps/lib-340a8c8c5623ea0f)

running 17 tests
test one_coroutine ... ok
test coroutine_result ... ok
test panic_coroutine ... ok
test go_with_macro ... ok
test test_yield ... ok
test scoped_coroutine ... ok
test wait_join ... ok
test yield_from_gen ... ok
test cancel_coroutine ... ok
test cancel_io_coroutine ... ok
test park_timeout ... ok
test unpark ... ok
test multi_yield ... ok
test multi_coroutine ... ok
test spawn_inside ... ok
test test_sleep ... ok
test join_macro ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.02s

     Running tests/local.rs (target/debug/deps/local-176c559952e58bdc)

running 3 tests
test local_in_thread ... ok
test coroutine_local ... ok
test coroutine_local_many ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

   Doc-tests may

running 43 tests
test src/os/unix/net.rs - os::unix::net::UnixDatagram::local_addr (line 751) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram::pair (line 680) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram::bind (line 638) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram::peer_addr (line 770) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram::connect (line 709) - compile ... ok
test src/os/unix/net.rs - os::unix::net::Incoming (line 566) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram (line 608) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram::read_timeout (line 987) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram::send (line 901) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram::send_to (line 865) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram::set_read_timeout (line 945) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram::recv_from (line 789) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram::set_write_timeout (line 969) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram::recv (line 826) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram::take_error (line 1022) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram::shutdown (line 1040) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram::try_clone (line 735) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixListener::accept (line 417) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram::write_timeout (line 1004) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixDatagram::unbound (line 658) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixListener (line 351) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixListener::incoming (line 506) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixListener::bind (line 393) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixListener::try_clone (line 455) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixListener::take_error (line 486) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixStream (line 24) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixListener::local_addr (line 471) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixStream::connect (line 60) - compile ... ok
test src/coroutine_impl.rs - coroutine_impl::Builder::spawn (line 331) ... ok
test src/os/unix/net.rs - os::unix::net::UnixStream::local_addr (line 135) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixStream::pair (line 93) - compile ... ok
test src/coroutine_impl.rs - coroutine_impl::Builder (line 194) ... ok
test src/coroutine_impl.rs - coroutine_impl::spawn (line 419) ... ok
test src/os/unix/net.rs - os::unix::net::UnixStream::set_read_timeout (line 167) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixStream::shutdown (line 259) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixStream::peer_addr (line 149) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixStream::set_write_timeout (line 188) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixStream::read_timeout (line 205) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixStream::take_error (line 239) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixStream::try_clone (line 120) - compile ... ok
test src/os/unix/net.rs - os::unix::net::UnixStream::write_timeout (line 222) - compile ... ok
test src/sync/semphore.rs - sync::semphore::Semphore (line 24) ... ok
test src/sync/sync_flag.rs - sync::sync_flag::SyncFlag (line 26) ... ok

test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.33s

```
</details>
