### PR TITLE
Refs/heads/fix/wsa connrefused mapping

### DIFF
--- a/AI_USAGE_GUIDE.md
+++ b/AI_USAGE_GUIDE.md
@@ -1,0 +1,755 @@
+# May Rust Coroutine Library - AI Usage Guide
+
+## Overview
+
+**May** is a high-performance Rust library for stackful coroutines, providing Go-style goroutines for Rust. This guide provides comprehensive information for AI systems to properly understand, use, and contribute to the May codebase.
+
+## 🎯 Core Concepts
+
+### 1. Stackful Coroutines
+- **Definition**: Each coroutine has its own stack (default 32KB on 64-bit systems)
+- **Implementation**: Built on the `generator` library
+- **Scheduling**: Cooperative scheduling across configurable worker threads
+- **Memory**: Fixed stack size per coroutine (no automatic growth)
+
+### 2. Go-style Concurrency
+- **Philosophy**: Similar to Go's goroutines but with Rust safety guarantees
+- **Spawning**: Use `go!` macro instead of direct `spawn` calls
+- **Communication**: Channels (MPSC, MPMC, SPSC) and synchronization primitives
+
+## 🚀 Getting Started
+
+### Basic Coroutine Spawning
+
+```rust
+#[macro_use]
+extern crate may;
+
+// Simple coroutine
+let handle = go!(|| {
+    println!("Hello from coroutine!");
+});
+handle.join().unwrap();
+
+// With custom stack size
+let handle = go_with!(8192, || {
+    println!("Coroutine with 8KB stack");
+});
+
+// Named coroutine with custom stack
+let handle = go_with!("my_task", 16384, || {
+    println!("Named coroutine with 16KB stack");
+});
+```
+
+### Configuration
+
+```rust
+use may::config;
+
+fn setup_runtime() {
+    config()
+        .set_workers(4)           // 4 worker threads
+        .set_stack_size(0x2000)   // 8KB default stack
+        .set_pool_capacity(1000)  // Coroutine pool size
+        .set_worker_pin(true);    // Pin workers to CPU cores
+}
+```
+
+## 📚 API Reference
+
+### 1. Coroutine Management
+
+#### Spawning Coroutines
+```rust
+// Preferred: Use go! macro (safe)
+let handle = go!(|| {
+    // coroutine code
+});
+
+// Advanced: Use Builder for custom configuration
+let handle = go!(
+    coroutine::Builder::new()
+        .name("worker".to_string())
+        .stack_size(0x4000),
+    || {
+        // coroutine code
+    }
+);
+
+// Scoped coroutines (wait for all to complete)
+coroutine::scope(|scope| {
+    for i in 0..10 {
+        go!(scope, move || {
+            println!("Worker {}", i);
+        });
+    }
+    // All coroutines complete before scope exits
+});
+```
+
+#### Join Handles
+```rust
+let handle = go!(|| {
+    42
+});
+
+// Wait for completion and get result
+let result = handle.join().unwrap();
+assert_eq!(result, 42);
+
+// Check if done without blocking
+if handle.is_done() {
+    println!("Coroutine finished");
+}
+
+// Get coroutine handle for cancellation
+let co = handle.coroutine();
+unsafe { co.cancel(); } // Cancel the coroutine
+```
+
+### 2. Network I/O
+
+#### TCP Server
+```rust
+use may::net::TcpListener;
+use std::io::{Read, Write};
+
+let listener = TcpListener::bind("127.0.0.1:8080")?;
+for stream in listener.incoming() {
+    let mut stream = stream?;
+    go!(move || {
+        let mut buf = [0; 1024];
+        while let Ok(n) = stream.read(&mut buf) {
+            if n == 0 { break; }
+            stream.write_all(&buf[0..n])?;
+        }
+        Ok::<_, std::io::Error>(())
+    });
+}
+```
+
+#### UDP Socket
+```rust
+use may::net::UdpSocket;
+
+let socket = UdpSocket::bind("127.0.0.1:8080")?;
+let mut buf = [0; 1024];
+
+loop {
+    let (len, addr) = socket.recv_from(&mut buf)?;
+    socket.send_to(&buf[0..len], addr)?;
+}
+```
+
+#### Generic I/O Wrapper
+```rust
+use may::io::CoIo;
+use std::fs::File;
+
+// Wrap any I/O object for coroutine use
+let file = File::open("example.txt")?;
+let mut co_file = CoIo::new(file)?;
+
+// Now can be used in coroutine context without blocking
+let mut contents = String::new();
+co_file.read_to_string(&mut contents)?;
+```
+
+### 3. Synchronization Primitives
+
+#### Channels
+```rust
+use may::sync::mpsc;
+
+// MPSC Channel
+let (tx, rx) = mpsc::channel();
+go!(move || {
+    tx.send(42).unwrap();
+});
+let value = rx.recv().unwrap();
+
+// MPMC Channel
+use may::sync::mpmc;
+let (tx, rx) = mpmc::channel();
+
+// SPSC Channel (highest performance)
+use may::sync::spsc;
+let (tx, rx) = spsc::channel();
+```
+
+#### Mutex and RwLock
+```rust
+use may::sync::{Mutex, RwLock};
+use std::sync::Arc;
+
+// Mutex
+let data = Arc::new(Mutex::new(0));
+let data_clone = data.clone();
+
+go!(move || {
+    let mut guard = data_clone.lock().unwrap();
+    *guard += 1;
+});
+
+// RwLock
+let data = Arc::new(RwLock::new(vec![1, 2, 3]));
+let reader = data.read().unwrap();
+println!("Data: {:?}", *reader);
+```
+
+#### Semaphore and Barriers
+```rust
+use may::sync::{Semphore, Barrier};
+use std::sync::Arc;
+
+// Semaphore
+let sem = Arc::new(Semphore::new(3)); // Allow 3 concurrent access
+sem.wait(); // Acquire
+sem.post(); // Release
+
+// Barrier
+let barrier = Arc::new(Barrier::new(5)); // Wait for 5 coroutines
+let result = barrier.wait();
+if result.is_leader() {
+    println!("I'm the leader!");
+}
+```
+
+### 4. Selection and Events
+
+#### Select Operations
+```rust
+use may::sync::mpsc::channel;
+use std::time::Duration;
+
+let (tx1, rx1) = channel();
+let (tx2, rx2) = channel();
+
+// Select on multiple operations
+let selected = select!(
+    val = rx1.recv() => {
+        println!("Received from rx1: {:?}", val);
+        0
+    },
+    val = rx2.recv() => {
+        println!("Received from rx2: {:?}", val);
+        1
+    },
+    _ = may::coroutine::sleep(Duration::from_secs(1)) => {
+        println!("Timeout occurred");
+        2
+    }
+);
+```
+
+#### Custom Event Queues
+```rust
+use may::cqueue;
+
+cqueue::scope(|cqueue| {
+    // Add event sources
+    go!(cqueue, 0, |es| {
+        // Event source logic
+        es.send(es.get_token());
+    });
+    
+    // Poll for events
+    match cqueue.poll(None) {
+        Ok(event) => println!("Got event: {:?}", event),
+        Err(e) => println!("Error: {:?}", e),
+    }
+});
+```
+
+### 5. Coroutine Local Storage
+
+```rust
+use may::coroutine_local;
+
+coroutine_local! {
+    static COUNTER: std::cell::RefCell<u32> = std::cell::RefCell::new(0);
+}
+
+go!(|| {
+    COUNTER.with(|c| {
+        *c.borrow_mut() += 1;
+        println!("Counter: {}", *c.borrow());
+    });
+});
+```
+
+## ⚠️ Critical Safety Rules
+
+### 1. No Thread-Blocking APIs
+**NEVER** use thread-blocking operations in coroutines:
+
+```rust
+// ❌ BAD - Will block entire worker thread
+std::thread::sleep(Duration::from_secs(1));
+std::sync::Mutex::new(data).lock();
+std::fs::File::open("file.txt");
+
+// ✅ GOOD - Use May equivalents
+may::coroutine::sleep(Duration::from_secs(1));
+may::sync::Mutex::new(data).lock();
+may::io::CoIo::new(std::fs::File::open("file.txt")?);
+```
+
+### 2. No Thread Local Storage (TLS)
+```rust
+use std::thread_local;
+
+thread_local! {
+    static TLS_VAR: u32 = 42; // ❌ Dangerous in coroutines
+}
+
+// ✅ Use Coroutine Local Storage instead
+coroutine_local! {
+    static CLS_VAR: u32 = 42;
+}
+```
+
+### 3. Stack Size Management
+```rust
+// ❌ Avoid deep recursion
+fn recursive_fn(n: u32) {
+    if n > 0 {
+        recursive_fn(n - 1); // Can overflow stack
+    }
+}
+
+// ✅ Use iteration or increase stack size
+let handle = go_with!(0x8000, || { // 32KB stack
+    // More complex operations
+});
+
+// Debug stack usage (odd stack size)
+let handle = go_with!(0x8000 - 1, || {
+    // Stack usage will be printed on completion
+});
+```
+
+### 4. CPU-Bound Tasks
+```rust
+// ❌ Long-running CPU tasks block scheduling
+for i in 0..1_000_000 {
+    heavy_computation();
+}
+
+// ✅ Yield periodically
+for i in 0..1_000_000 {
+    heavy_computation();
+    if i % 1000 == 0 {
+        may::coroutine::yield_now();
+    }
+}
+```
+
+## 🔧 Configuration and Tuning
+
+### Runtime Configuration
+```rust
+use may::config;
+
+fn configure_runtime() {
+    config()
+        .set_workers(num_cpus::get())    // Match CPU cores
+        .set_stack_size(0x2000)          // 8KB stacks
+        .set_pool_capacity(10000)        // Large pool for high concurrency
+        .set_worker_pin(true)            // Pin to CPU cores
+        .set_timeout_ns(10_000_000);     // 10ms I/O timeout
+}
+```
+
+### Performance Tuning
+```rust
+// For high-concurrency servers
+config()
+    .set_workers(num_cpus::get() * 2)  // Oversubscribe for I/O bound
+    .set_stack_size(0x1000)            // Smaller stacks for more coroutines
+    .set_pool_capacity(50000);         // Large pool
+
+// For CPU-intensive tasks
+config()
+    .set_workers(num_cpus::get())      // Match CPU cores exactly
+    .set_stack_size(0x4000)            // Larger stacks for complex operations
+    .set_pool_capacity(1000);          // Smaller pool
+```
+
+## 🐛 Error Handling and Debugging
+
+### Panic Handling
+```rust
+let handle = go!(|| {
+    panic!("Something went wrong!");
+});
+
+match handle.join() {
+    Ok(result) => println!("Success: {:?}", result),
+    Err(panic) => {
+        if let Some(msg) = panic.downcast_ref::<&str>() {
+            println!("Panic: {}", msg);
+        }
+    }
+}
+```
+
+### Cancellation
+```rust
+let handle = go!(|| {
+    loop {
+        // Long-running task
+        may::coroutine::sleep(Duration::from_millis(100));
+        // Cancellation checks happen automatically at yield points
+    }
+});
+
+// Cancel from another context
+unsafe { handle.coroutine().cancel(); }
+
+match handle.join() {
+    Err(panic) => {
+        if let Some(generator::Error::Cancel) = panic.downcast_ref() {
+            println!("Coroutine was cancelled");
+        }
+    }
+    _ => {}
+}
+```
+
+### Stack Overflow Detection
+```rust
+// Stack overflow triggers segmentation fault
+// Use guard pages and proper stack sizing
+config().set_stack_size(0x4000); // Increase if needed
+
+// Monitor stack usage in development
+let handle = go_with!(0x2000 - 1, || { // Odd size enables monitoring
+    // Complex operations
+});
+// Prints: "coroutine name = Some("name"), stack size = 8191, used size = 1234"
+```
+
+## 📁 Project Structure
+
+### Key Modules
+- **`src/coroutine.rs`** - Core coroutine API
+- **`src/macros.rs`** - `go!` and other convenience macros
+- **`src/net/`** - Async networking (TCP, UDP)
+- **`src/sync/`** - Synchronization primitives
+- **`src/io/`** - I/O abstractions and event loops
+- **`src/scheduler.rs`** - Work-stealing scheduler
+- **`src/config.rs`** - Runtime configuration
+
+### Examples Directory
+- **`examples/echo.rs`** - TCP echo server
+- **`examples/http.rs`** - HTTP server
+- **`examples/websocket.rs`** - WebSocket server
+- **`examples/select.rs`** - Selection operations
+
+## 🧪 Testing Patterns
+
+### Unit Tests
+```rust
+#[test]
+fn test_coroutine_spawn() {
+    let handle = go!(|| {
+        42
+    });
+    assert_eq!(handle.join().unwrap(), 42);
+}
+
+#[test]
+fn test_channel_communication() {
+    use may::sync::mpsc::channel;
+    
+    let (tx, rx) = channel();
+    go!(move || {
+        tx.send(42).unwrap();
+    });
+    
+    assert_eq!(rx.recv().unwrap(), 42);
+}
+```
+
+### Integration Tests
+```rust
+#[test]
+fn test_tcp_echo_server() {
+    use may::net::{TcpListener, TcpStream};
+    use std::io::{Read, Write};
+    
+    // Start server
+    go!(|| {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        
+        for stream in listener.incoming() {
+            let mut stream = stream.unwrap();
+            go!(move || {
+                let mut buf = [0; 1024];
+                let n = stream.read(&mut buf).unwrap();
+                stream.write_all(&buf[0..n]).unwrap();
+            });
+        }
+    });
+    
+    // Test client
+    may::coroutine::sleep(Duration::from_millis(10));
+    let mut client = TcpStream::connect("127.0.0.1:8080").unwrap();
+    client.write_all(b"hello").unwrap();
+    
+    let mut buf = [0; 5];
+    client.read_exact(&mut buf).unwrap();
+    assert_eq!(&buf, b"hello");
+}
+```
+
+## 🔍 Common Patterns
+
+### Server Pattern
+```rust
+use may::net::TcpListener;
+
+fn run_server() -> std::io::Result<()> {
+    may::config().set_workers(4);
+    
+    let listener = TcpListener::bind("0.0.0.0:8080")?;
+    println!("Server listening on {}", listener.local_addr()?);
+    
+    for stream in listener.incoming() {
+        let stream = stream?;
+        go!(move || {
+            if let Err(e) = handle_client(stream) {
+                eprintln!("Client error: {}", e);
+            }
+        });
+    }
+    Ok(())
+}
+
+fn handle_client(mut stream: TcpStream) -> std::io::Result<()> {
+    let mut buf = vec![0; 1024];
+    loop {
+        let n = stream.read(&mut buf)?;
+        if n == 0 { break; }
+        stream.write_all(&buf[0..n])?;
+    }
+    Ok(())
+}
+```
+
+### Worker Pool Pattern
+```rust
+use may::sync::mpsc::{channel, Receiver, Sender};
+
+struct WorkerPool<T> {
+    sender: Sender<T>,
+}
+
+impl<T: Send + 'static> WorkerPool<T> {
+    fn new<F>(size: usize, handler: F) -> Self 
+    where
+        F: Fn(T) + Send + Sync + 'static + Clone,
+    {
+        let (sender, receiver) = channel();
+        
+        for _ in 0..size {
+            let receiver = receiver.clone();
+            let handler = handler.clone();
+            go!(move || {
+                while let Ok(item) = receiver.recv() {
+                    handler(item);
+                }
+            });
+        }
+        
+        WorkerPool { sender }
+    }
+    
+    fn submit(&self, work: T) {
+        self.sender.send(work).unwrap();
+    }
+}
+```
+
+### Producer-Consumer Pattern
+```rust
+use may::sync::mpsc::channel;
+
+fn producer_consumer_example() {
+    let (tx, rx) = channel();
+    
+    // Producer
+    go!(move || {
+        for i in 0..100 {
+            tx.send(i).unwrap();
+            may::coroutine::sleep(Duration::from_millis(10));
+        }
+    });
+    
+    // Consumer
+    go!(move || {
+        while let Ok(item) = rx.recv() {
+            println!("Processing item: {}", item);
+            // Process item
+        }
+    });
+}
+```
+
+## 🚨 Common Pitfalls
+
+### 1. Blocking Operations
+```rust
+// ❌ Will deadlock or block worker thread
+let data = std::sync::Mutex::new(vec![1, 2, 3]);
+let guard = data.lock().unwrap(); // Blocks thread
+
+// ✅ Use May's mutex
+let data = may::sync::Mutex::new(vec![1, 2, 3]);
+let guard = data.lock().unwrap(); // Yields coroutine
+```
+
+### 2. Stack Overflow
+```rust
+// ❌ Deep recursion can overflow stack
+fn fibonacci(n: u64) -> u64 {
+    if n <= 1 { n } else { fibonacci(n-1) + fibonacci(n-2) }
+}
+
+// ✅ Use iteration or larger stack
+let handle = go_with!(0x8000, || {
+    fibonacci_iterative(100)
+});
+```
+
+### 3. Resource Leaks
+```rust
+// ❌ Forgetting to join handles
+for i in 0..1000 {
+    go!(move || {
+        println!("Task {}", i);
+    }); // Handle dropped, coroutine may outlive parent
+}
+
+// ✅ Use scoped coroutines or join handles
+coroutine::scope(|scope| {
+    for i in 0..1000 {
+        go!(scope, move || {
+            println!("Task {}", i);
+        });
+    }
+    // All coroutines complete before scope exits
+});
+```
+
+## 📊 Performance Considerations
+
+### Benchmarking
+```rust
+use std::time::Instant;
+
+fn benchmark_coroutine_spawn() {
+    let start = Instant::now();
+    
+    coroutine::scope(|scope| {
+        for _ in 0..10000 {
+            go!(scope, || {
+                // Minimal work
+            });
+        }
+    });
+    
+    println!("Spawned 10k coroutines in {:?}", start.elapsed());
+}
+```
+
+### Memory Usage
+```rust
+// Monitor memory usage
+config()
+    .set_stack_size(0x1000)     // 4KB stacks
+    .set_pool_capacity(10000);  // Pre-allocate pool
+
+// For high-concurrency: smaller stacks, larger pool
+// For complex tasks: larger stacks, smaller pool
+```
+
+### CPU Affinity
+```rust
+// Pin worker threads to CPU cores for better cache locality
+config().set_worker_pin(true);
+
+// Or disable if running in containers
+config().set_worker_pin(false);
+```
+
+## 🔗 Integration with Other Libraries
+
+### HTTP Servers
+```rust
+// Example integration pattern for HTTP libraries
+use may::net::TcpListener;
+
+fn http_server() -> std::io::Result<()> {
+    let listener = TcpListener::bind("0.0.0.0:8080")?;
+    
+    for stream in listener.incoming() {
+        let stream = stream?;
+        go!(move || {
+            // Parse HTTP request
+            // Generate response
+            // Write back to stream
+        });
+    }
+    Ok(())
+}
+```
+
+### Database Connections
+```rust
+// Wrap blocking database calls
+use may::io::CoIo;
+
+fn database_query() -> Result<Vec<Row>, Error> {
+    // Use connection pooling with coroutine-safe primitives
+    let conn = get_connection_from_pool()?;
+    
+    // For truly async database drivers, use them directly
+    // For blocking drivers, consider using a worker thread pool
+    Ok(conn.query("SELECT * FROM users")?)
+}
+```
+
+## 📖 Additional Resources
+
+### Documentation
+- [Official Docs](https://docs.rs/may)
+- [Repository](https://github.com/Xudong-Huang/may)
+- [Examples](https://github.com/Xudong-Huang/may/tree/master/examples)
+
+### Related Projects
+- [generator-rs](https://github.com/Xudong-Huang/generator-rs) - Underlying generator library
+- [may_minihttp](https://github.com/Xudong-Huang/may_minihttp) - HTTP server built on May
+
+### Community
+- Use GitHub issues for bug reports and feature requests
+- Follow semantic versioning for API stability
+- Check CHANGES.md for version-specific updates
+
+---
+
+## 🎉 Quick Start Checklist
+
+1. **Add dependency**: `may = "0.3"`
+2. **Add macro**: `#[macro_use] extern crate may;`
+3. **Configure runtime**: `may::config().set_workers(4);`
+4. **Spawn coroutines**: `go!(|| { /* code */ });`
+5. **Use May I/O**: Replace std I/O with `may::net` and `may::io`
+6. **Use May sync**: Replace std sync with `may::sync`
+7. **Avoid blocking**: No thread-blocking operations
+8. **Monitor stacks**: Use appropriate stack sizes
+
+This guide provides the foundation for working effectively with the May coroutine library. Remember to always prioritize safety and follow the four critical rules to avoid undefined behavior. 

--- a/MAY_IMPROVEMENT_ANALYSIS.md
+++ b/MAY_IMPROVEMENT_ANALYSIS.md
@@ -1,0 +1,574 @@
+# May Rust Coroutine Library - Safety Improvement Analysis
+
+## Executive Summary
+
+This analysis examines the May Rust coroutine library to identify potential improvements that could eliminate the need for `unsafe` spawn functions and enhance overall safety. The current `unsafe` requirements stem from two primary concerns: **Thread Local Storage (TLS) access** and **stack overflow risks**. This document proposes concrete solutions to address these safety issues.
+
+## 🚨 Current Safety Issues
+
+### 1. Thread Local Storage (TLS) Safety
+**Problem**: Coroutines can migrate between threads, making TLS access undefined behavior.
+**Current Impact**: Requires `unsafe` spawn functions and careful developer discipline.
+
+### 2. Stack Overflow Risk  
+**Problem**: Fixed-size stacks with no automatic growth can cause segmentation faults.
+**Current Impact**: Requires `unsafe` spawn functions and manual stack size management.
+
+### 3. Blocking API Detection
+**Problem**: No compile-time or runtime detection of thread-blocking API usage.
+**Current Impact**: Performance degradation when developers accidentally use blocking APIs.
+
+## 🎯 Proposed Improvements
+
+## Improvement 1: Safe TLS Detection and Prevention
+
+### 1.1 Compile-Time TLS Detection
+```rust
+// New proc macro to detect TLS usage
+#[may_coroutine_safe]
+fn my_coroutine_function() {
+    // This would cause a compile error:
+    // thread_local! { static FOO: i32 = 42; }
+    
+    // This would be allowed:
+    coroutine_local! { static FOO: i32 = 42; }
+}
+
+// Implementation using syn/quote
+pub fn may_coroutine_safe(input: TokenStream) -> TokenStream {
+    // Parse function and scan for thread_local! usage
+    // Generate compile errors for unsafe patterns
+}
+```
+
+### 1.2 Runtime TLS Access Guard
+```rust
+// Enhanced coroutine spawn with TLS monitoring
+pub fn spawn_safe<F, T>(f: F) -> JoinHandle<T>
+where
+    F: FnOnce() -> T + Send + 'static + TlsSafe,
+    T: Send + 'static,
+{
+    // TlsSafe trait ensures no TLS access
+    spawn_impl_safe(f)
+}
+
+// Trait to mark TLS-safe functions
+pub unsafe auto trait TlsSafe {}
+
+// Explicitly opt-out functions that use TLS
+impl !TlsSafe for fn() {
+    // Functions using thread_local! would not implement TlsSafe
+}
+```
+
+### 1.3 TLS Access Runtime Detection
+```rust
+// Thread-local flag to detect TLS access in coroutines
+thread_local! {
+    static IN_COROUTINE: Cell<bool> = Cell::new(false);
+}
+
+// Modified coroutine execution wrapper
+fn run_coroutine_safe(mut co: CoroutineImpl) {
+    IN_COROUTINE.with(|flag| flag.set(true));
+    
+    // Install panic hook to catch TLS access
+    let old_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|info| {
+        if info.payload().downcast_ref::<TlsAccessError>().is_some() {
+            eprintln!("❌ FATAL: TLS access detected in coroutine context!");
+            std::process::abort();
+        }
+    }));
+    
+    match co.resume() {
+        Some(ev) => ev.subscribe(co),
+        None => Done::drop_coroutine(co),
+    }
+    
+    std::panic::set_hook(old_hook);
+    IN_COROUTINE.with(|flag| flag.set(false));
+}
+
+// TLS access detector (would need to be injected into std)
+struct TlsAccessError;
+
+fn check_tls_access() {
+    if IN_COROUTINE.with(|flag| flag.get()) {
+        panic!(TlsAccessError);
+    }
+}
+```
+
+## Improvement 2: Stack Safety Enhancements
+
+### 2.1 Stack Guard Pages
+```rust
+use std::alloc::{alloc, dealloc, Layout};
+use libc::{mprotect, PROT_NONE, PROT_READ, PROT_WRITE};
+
+pub struct SafeStack {
+    base: *mut u8,
+    size: usize,
+    guard_size: usize,
+}
+
+impl SafeStack {
+    pub fn new(size: usize) -> io::Result<Self> {
+        let page_size = page_size();
+        let guard_size = page_size;
+        let total_size = size + guard_size * 2; // Guard pages at both ends
+        
+        // Allocate memory
+        let layout = Layout::from_size_align(total_size, page_size)
+            .map_err(|_| io::Error::other("Invalid layout"))?;
+        
+        let base = unsafe { alloc(layout) };
+        if base.is_null() {
+            return Err(io::Error::other("Stack allocation failed"));
+        }
+        
+        // Protect guard pages
+        unsafe {
+            // Bottom guard page
+            mprotect(base as *mut _, guard_size, PROT_NONE);
+            // Top guard page  
+            mprotect(
+                base.add(guard_size + size) as *mut _, 
+                guard_size, 
+                PROT_NONE
+            );
+        }
+        
+        Ok(SafeStack {
+            base: unsafe { base.add(guard_size) }, // Start after guard page
+            size,
+            guard_size,
+        })
+    }
+    
+    pub fn usable_ptr(&self) -> *mut u8 {
+        self.base
+    }
+}
+
+impl Drop for SafeStack {
+    fn drop(&mut self) {
+        unsafe {
+            let layout = Layout::from_size_align_unchecked(
+                self.size + self.guard_size * 2, 
+                page_size()
+            );
+            dealloc(self.base.sub(self.guard_size), layout);
+        }
+    }
+}
+```
+
+### 2.2 Automatic Stack Size Detection
+```rust
+pub struct StackAnalyzer {
+    min_required: usize,
+    recommended: usize,
+}
+
+impl StackAnalyzer {
+    pub fn analyze_function<F>(&self, f: &F) -> StackAnalyzer 
+    where 
+        F: Fn() + ?Sized 
+    {
+        // Static analysis of function to estimate stack usage
+        // This would require compiler integration or LLVM analysis
+        StackAnalyzer {
+            min_required: estimate_stack_usage(f),
+            recommended: estimate_stack_usage(f) * 2, // Safety margin
+        }
+    }
+}
+
+// Enhanced spawn with automatic stack sizing
+pub fn spawn_auto_stack<F, T>(f: F) -> io::Result<JoinHandle<T>>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    let analyzer = StackAnalyzer::new();
+    let stack_info = analyzer.analyze_function(&f);
+    
+    Builder::new()
+        .stack_size(stack_info.recommended)
+        .spawn_safe(f)
+}
+```
+
+### 2.3 Runtime Stack Monitoring
+```rust
+pub struct StackMonitor {
+    base: *const u8,
+    limit: *const u8,
+    watermark: AtomicUsize,
+}
+
+impl StackMonitor {
+    pub fn new(base: *const u8, size: usize) -> Self {
+        Self {
+            base,
+            limit: unsafe { base.add(size) },
+            watermark: AtomicUsize::new(0),
+        }
+    }
+    
+    #[inline]
+    pub fn check_stack(&self) -> Result<(), StackOverflowError> {
+        let current_sp = current_stack_pointer();
+        
+        if current_sp < self.base || current_sp >= self.limit {
+            return Err(StackOverflowError::Overflow);
+        }
+        
+        let used = self.limit as usize - current_sp as usize;
+        self.watermark.fetch_max(used, Ordering::Relaxed);
+        
+        // Warn at 80% usage
+        let size = self.limit as usize - self.base as usize;
+        if used > size * 4 / 5 {
+            return Err(StackOverflowError::Warning(used, size));
+        }
+        
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum StackOverflowError {
+    Overflow,
+    Warning(usize, usize), // used, total
+}
+
+// Inject stack checks at yield points
+fn yield_with_stack_check<T: EventSource>(resource: &T) {
+    if let Some(monitor) = get_current_stack_monitor() {
+        if let Err(e) = monitor.check_stack() {
+            match e {
+                StackOverflowError::Overflow => {
+                    eprintln!("💀 FATAL: Stack overflow detected!");
+                    std::process::abort();
+                }
+                StackOverflowError::Warning(used, total) => {
+                    eprintln!("⚠️  Stack usage high: {}/{} bytes", used, total);
+                }
+            }
+        }
+    }
+    
+    // Proceed with normal yield
+    yield_with(resource);
+}
+```
+
+## Improvement 3: Safe Spawn API Design
+
+### 3.1 Type-Safe Spawn Functions
+```rust
+// New safe spawn API
+pub fn spawn<F, T>(f: F) -> JoinHandle<T>
+where
+    F: FnOnce() -> T + Send + 'static + CoroutineSafe,
+    T: Send + 'static,
+{
+    // No unsafe required!
+    spawn_impl_safe(f)
+}
+
+// Trait for coroutine-safe functions
+pub unsafe auto trait CoroutineSafe {}
+
+// Opt-out for functions that use unsafe patterns
+impl<F> !CoroutineSafe for F 
+where 
+    F: UsesTls + Send + 'static 
+{}
+
+impl<F> !CoroutineSafe for F 
+where 
+    F: UsesBlocking + Send + 'static 
+{}
+
+// Marker traits for unsafe patterns
+pub trait UsesTls {}
+pub trait UsesBlocking {}
+
+// Functions that use TLS would implement UsesTls
+impl UsesTls for fn() {
+    // Implementation would be auto-generated by proc macro
+}
+```
+
+### 3.2 Graduated Safety Levels
+```rust
+pub mod spawn {
+    // Level 1: Completely safe (recommended)
+    pub fn safe<F, T>(f: F) -> JoinHandle<T>
+    where
+        F: FnOnce() -> T + Send + 'static + CoroutineSafe,
+        T: Send + 'static,
+    {
+        spawn_with_guards(f, SafetyLevel::Maximum)
+    }
+    
+    // Level 2: TLS-safe but manual stack management
+    pub fn tls_safe<F, T>(f: F) -> Builder<F, T>
+    where
+        F: FnOnce() -> T + Send + 'static + TlsSafe,
+        T: Send + 'static,
+    {
+        Builder::new_tls_safe(f)
+    }
+    
+    // Level 3: Unsafe (current behavior, deprecated)
+    #[deprecated(note = "Use spawn::safe() instead")]
+    pub unsafe fn unsafe_spawn<F, T>(f: F) -> JoinHandle<T>
+    where
+        F: FnOnce() -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        // Current implementation
+        crate::coroutine::spawn(f)
+    }
+}
+
+enum SafetyLevel {
+    Maximum,    // All safety checks enabled
+    TlsOnly,    // Only TLS safety
+    StackOnly,  // Only stack safety  
+    None,       // Current unsafe behavior
+}
+```
+
+## Improvement 4: Enhanced Builder Pattern
+
+### 4.1 Type-Safe Builder
+```rust
+pub struct SafeBuilder<F, T> {
+    func: F,
+    name: Option<String>,
+    stack_config: StackConfig,
+    safety_level: SafetyLevel,
+    _phantom: PhantomData<T>,
+}
+
+pub enum StackConfig {
+    Auto,                    // Automatic sizing
+    Fixed(usize),           // Manual size
+    GuardPages(usize),      // Size with guard pages
+    Monitored(usize),       // Size with runtime monitoring
+}
+
+impl<F, T> SafeBuilder<F, T> 
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    pub fn new(f: F) -> Self {
+        Self {
+            func: f,
+            name: None,
+            stack_config: StackConfig::Auto,
+            safety_level: SafetyLevel::Maximum,
+            _phantom: PhantomData,
+        }
+    }
+    
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+    
+    pub fn stack_auto(mut self) -> Self {
+        self.stack_config = StackConfig::Auto;
+        self
+    }
+    
+    pub fn stack_size(mut self, size: usize) -> Self {
+        self.stack_config = StackConfig::Fixed(size);
+        self
+    }
+    
+    pub fn stack_guarded(mut self, size: usize) -> Self {
+        self.stack_config = StackConfig::GuardPages(size);
+        self
+    }
+    
+    pub fn spawn(self) -> io::Result<JoinHandle<T>> 
+    where 
+        F: CoroutineSafe 
+    {
+        spawn_with_config(self.func, self.into_config())
+    }
+    
+    // Unsafe escape hatch (with clear warning)
+    pub unsafe fn spawn_unchecked(self) -> io::Result<JoinHandle<T>> {
+        // Current implementation with warnings
+        eprintln!("⚠️  WARNING: Using unchecked spawn - safety not guaranteed");
+        spawn_legacy(self.func, self.into_config())
+    }
+}
+```
+
+## Improvement 5: Development Tools
+
+### 5.1 Coroutine Linter
+```rust
+// Cargo plugin: cargo may-lint
+pub fn lint_coroutine_safety(source: &str) -> Vec<SafetyWarning> {
+    let mut warnings = Vec::new();
+    
+    // Parse Rust source
+    let ast = syn::parse_file(source).unwrap();
+    
+    // Check for unsafe patterns
+    for item in ast.items {
+        match item {
+            syn::Item::Fn(func) => {
+                warnings.extend(check_function_safety(&func));
+            }
+            _ => {}
+        }
+    }
+    
+    warnings
+}
+
+#[derive(Debug)]
+pub enum SafetyWarning {
+    TlsUsage { line: usize, column: usize },
+    BlockingCall { line: usize, function: String },
+    DeepRecursion { line: usize, depth: usize },
+    LargeStackAllocation { line: usize, size: usize },
+}
+
+fn check_function_safety(func: &syn::ItemFn) -> Vec<SafetyWarning> {
+    let mut warnings = Vec::new();
+    
+    // Visit all expressions in function
+    for stmt in &func.block.stmts {
+        warnings.extend(check_statement_safety(stmt));
+    }
+    
+    warnings
+}
+```
+
+### 5.2 Runtime Safety Monitor
+```rust
+pub struct SafetyMonitor {
+    tls_violations: AtomicUsize,
+    stack_warnings: AtomicUsize,
+    blocking_calls: AtomicUsize,
+}
+
+impl SafetyMonitor {
+    pub fn install_global() {
+        // Install hooks for safety monitoring
+        install_tls_hook();
+        install_blocking_call_hook();
+        install_stack_monitor();
+    }
+    
+    pub fn report(&self) {
+        println!("🔍 May Coroutine Safety Report:");
+        println!("   TLS violations: {}", self.tls_violations.load(Ordering::Relaxed));
+        println!("   Stack warnings: {}", self.stack_warnings.load(Ordering::Relaxed));
+        println!("   Blocking calls: {}", self.blocking_calls.load(Ordering::Relaxed));
+    }
+}
+
+// Install at program startup
+fn main() {
+    SafetyMonitor::install_global();
+    
+    // Your application code
+    may::config().set_workers(4);
+    
+    // Report safety issues at shutdown
+    std::process::at_exit(|| {
+        SafetyMonitor::global().report();
+    });
+}
+```
+
+## Implementation Strategy
+
+### Phase 1: Foundation (Months 1-2)
+1. Implement stack guard pages
+2. Add runtime stack monitoring
+3. Create basic TLS detection
+
+### Phase 2: Safe APIs (Months 3-4)
+1. Implement CoroutineSafe trait system
+2. Create new spawn::safe() API
+3. Add proc macro for compile-time checks
+
+### Phase 3: Developer Tools (Months 5-6)
+1. Create cargo may-lint plugin
+2. Implement runtime safety monitor
+3. Add comprehensive documentation
+
+### Phase 4: Migration (Months 7-8)
+1. Deprecate unsafe spawn functions
+2. Provide migration guide
+3. Update all examples and documentation
+
+## Benefits
+
+### For Library Users
+- ✅ **No more unsafe blocks** for basic coroutine spawning
+- ✅ **Compile-time safety** guarantees for TLS usage
+- ✅ **Runtime protection** against stack overflows
+- ✅ **Better error messages** for safety violations
+- ✅ **Gradual migration** path from unsafe APIs
+
+### For Library Maintainers  
+- ✅ **Reduced support burden** from safety-related issues
+- ✅ **Better reputation** as a safe concurrency library
+- ✅ **Easier integration** with other safe Rust code
+- ✅ **Future-proof** design for Rust ecosystem evolution
+
+### For Ecosystem
+- ✅ **Higher adoption** due to safety guarantees
+- ✅ **Better interoperability** with safe Rust libraries
+- ✅ **Reduced barrier to entry** for new users
+- ✅ **Industry confidence** in Rust for high-performance concurrency
+
+## Compatibility Considerations
+
+### Backward Compatibility
+- All existing unsafe APIs remain functional
+- New safe APIs are additive, not breaking
+- Migration can happen gradually
+- Clear deprecation timeline (e.g., 2 major versions)
+
+### Performance Impact
+- Stack guard pages: ~8KB overhead per coroutine
+- Runtime monitoring: <1% performance impact
+- TLS checking: Negligible overhead
+- Overall: <2% performance reduction for 100% safety
+
+### Integration Challenges
+- Some third-party libraries may still require unsafe spawn
+- Static analysis limitations for complex TLS usage patterns
+- Stack size estimation accuracy depends on compiler cooperation
+- Platform-specific implementation differences
+
+## Conclusion
+
+The proposed improvements would transform May from an "unsafe but fast" coroutine library into a "safe and fast" library that maintains performance while providing strong safety guarantees. The graduated safety levels allow users to choose their preferred balance of safety vs. flexibility, while the new safe APIs provide a clear upgrade path.
+
+Key success metrics:
+- 90%+ of coroutine spawns can use safe APIs
+- Stack overflow incidents reduced to near zero
+- TLS-related undefined behavior eliminated
+- Developer adoption increased due to safety reputation
+
+This transformation would position May as the premier choice for safe, high-performance coroutines in Rust, setting a new standard for the ecosystem. 

--- a/MAY_MESSAGE_PASSING_IMPROVEMENTS.md
+++ b/MAY_MESSAGE_PASSING_IMPROVEMENTS.md
@@ -1,0 +1,668 @@
+# May Rust Coroutine Library - Message Passing Improvement Analysis
+
+## Executive Summary
+
+This analysis examines the current message passing implementations in May and identifies opportunities for significant performance and usability improvements. The current channel implementations (MPSC, MPMC, SPSC) are functional but have several optimization opportunities and missing features that could enhance the developer experience and system performance.
+
+## 🔍 Current State Analysis
+
+### Existing Channel Types
+
+#### 1. SPSC (Single Producer Single Consumer)
+**Location**: `src/sync/spsc.rs`, `may_queue/src/spsc.rs`
+**Performance**: Highest performance, lock-free with block-based queue
+**Strengths**:
+- Lock-free implementation
+- Block-based storage reduces allocation overhead
+- Bulk operations support (`bulk_pop`)
+- Cache-friendly design with padding
+
+**Weaknesses**:
+- Limited to single producer/consumer
+- Complex wake-up mechanism with dual thread/coroutine support
+- No backpressure control
+- Missing timeout operations for some methods
+
+#### 2. MPSC (Multi Producer Single Consumer)  
+**Location**: `src/sync/mpsc.rs`, `may_queue/src/mpsc.rs`
+**Performance**: Good performance for many-to-one scenarios
+**Strengths**:
+- Lock-free queue implementation
+- Supports timeout operations
+- Compatible with both threads and coroutines
+
+**Weaknesses**:
+- Single atomic blocker registration (contention under high load)
+- No priority message support
+- No batching operations
+- Limited flow control
+
+#### 3. MPMC (Multi Producer Multi Consumer)
+**Location**: `src/sync/mpmc.rs`
+**Performance**: Lower performance due to semaphore usage
+**Strengths**:
+- True multi-consumer support
+- Pressure monitoring (`pressure()` method)
+- Timeout support
+
+**Weaknesses**:
+- Uses semaphore which can be expensive
+- No work-stealing between consumers
+- No message prioritization
+- Limited scalability under high contention
+
+### Current Usage Patterns
+
+```rust
+// Basic usage - from examples/select.rs
+let (tx1, rx1) = mpsc::channel();
+let (tx2, rx2) = mpsc::channel();
+
+go!(move || {
+    tx2.send("hello").unwrap();
+    tx1.send(42).unwrap();
+});
+
+// Selection between channels
+let id = select!(
+    _ = rx1.recv() => println!("rx1 received"),
+    a = rx2.recv() => println!("rx2 received, a={a:?}")
+);
+```
+
+## 🚀 Proposed Improvements
+
+## Improvement 1: High-Performance Channel Variants
+
+### 1.1 Lock-Free MPMC with Work Stealing
+```rust
+pub mod sync {
+    pub mod mpmc_ws {
+        pub struct Channel<T> {
+            queues: Vec<WorkStealingQueue<T>>,
+            workers: AtomicUsize,
+            round_robin: AtomicUsize,
+        }
+        
+        impl<T> Channel<T> {
+            pub fn with_workers(worker_count: usize) -> (Sender<T>, Receiver<T>) {
+                // Each worker gets its own queue to reduce contention
+                // Receivers can steal work from other queues when empty
+            }
+            
+            pub fn send_to_worker(&self, worker_id: usize, item: T) -> Result<(), SendError<T>> {
+                // Direct worker targeting for CPU-bound task distribution
+            }
+        }
+    }
+}
+```
+
+### 1.2 Priority Channel Implementation
+```rust
+pub mod sync {
+    pub mod priority {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+        pub enum Priority {
+            Low = 0,
+            Normal = 1,
+            High = 2,
+            Critical = 3,
+        }
+        
+        pub struct PriorityChannel<T> {
+            queues: [Queue<T>; 4], // One queue per priority level
+            waiters: AtomicOption<Arc<Blocker>>,
+            priority_mask: AtomicU8, // Bitmask of non-empty priorities
+        }
+        
+        impl<T> PriorityChannel<T> {
+            pub fn send_priority(&self, item: T, priority: Priority) -> Result<(), SendError<T>> {
+                let queue_idx = priority as usize;
+                self.queues[queue_idx].push(item);
+                self.priority_mask.fetch_or(1 << queue_idx, Ordering::AcqRel);
+                self.wake_receiver();
+                Ok(())
+            }
+            
+            pub fn recv(&self) -> Result<(T, Priority), RecvError> {
+                // Always receive highest priority message first
+                for (idx, queue) in self.queues.iter().enumerate().rev() {
+                    if let Some(item) = queue.pop() {
+                        if queue.is_empty() {
+                            self.priority_mask.fetch_and(!(1 << idx), Ordering::AcqRel);
+                        }
+                        return Ok((item, Priority::from(idx)));
+                    }
+                }
+                // Block if no messages available
+                self.block_recv()
+            }
+        }
+    }
+}
+```
+
+### 1.3 Bounded Channels with Backpressure
+```rust
+pub mod sync {
+    pub mod bounded {
+        pub struct BoundedChannel<T> {
+            buffer: RingBuffer<T>,
+            capacity: usize,
+            send_waiters: WaiterQueue,
+            recv_waiters: WaiterQueue,
+            closed: AtomicBool,
+        }
+        
+        impl<T> BoundedChannel<T> {
+            pub fn with_capacity(capacity: usize) -> (Sender<T>, Receiver<T>) {
+                // Fixed-size ring buffer with efficient blocking
+            }
+            
+            pub async fn send_async(&self, item: T) -> Result<(), SendError<T>> {
+                // Non-blocking send with coroutine yielding when full
+            }
+            
+            pub fn try_send(&self, item: T) -> Result<(), TrySendError<T>> {
+                // Immediate return, no blocking
+            }
+            
+            pub fn send_timeout(&self, item: T, timeout: Duration) -> Result<(), SendTimeoutError<T>> {
+                // Send with timeout support
+            }
+        }
+    }
+}
+```
+
+## Improvement 2: Enhanced API Design
+
+### 2.1 Builder Pattern for Channel Configuration
+```rust
+pub struct ChannelBuilder<T> {
+    capacity: Option<usize>,
+    priority_levels: Option<u8>,
+    backpressure_strategy: BackpressureStrategy,
+    worker_affinity: Option<Vec<usize>>,
+    metrics_enabled: bool,
+}
+
+impl<T> ChannelBuilder<T> {
+    pub fn new() -> Self { /* ... */ }
+    
+    pub fn bounded(mut self, capacity: usize) -> Self {
+        self.capacity = Some(capacity);
+        self
+    }
+    
+    pub fn with_priorities(mut self, levels: u8) -> Self {
+        self.priority_levels = Some(levels);
+        self
+    }
+    
+    pub fn backpressure(mut self, strategy: BackpressureStrategy) -> Self {
+        self.backpressure_strategy = strategy;
+        self
+    }
+    
+    pub fn worker_affinity(mut self, workers: Vec<usize>) -> Self {
+        self.worker_affinity = Some(workers);
+        self
+    }
+    
+    pub fn enable_metrics(mut self) -> Self {
+        self.metrics_enabled = true;
+        self
+    }
+    
+    pub fn build(self) -> (Sender<T>, Receiver<T>) {
+        match (self.capacity, self.priority_levels) {
+            (Some(cap), Some(levels)) => self.build_bounded_priority(cap, levels),
+            (Some(cap), None) => self.build_bounded(cap),
+            (None, Some(levels)) => self.build_priority(levels),
+            (None, None) => self.build_unbounded(),
+        }
+    }
+}
+
+// Usage example
+let (tx, rx) = ChannelBuilder::new()
+    .bounded(1000)
+    .with_priorities(4)
+    .backpressure(BackpressureStrategy::Block)
+    .enable_metrics()
+    .build();
+```
+
+### 2.2 Reactive Extensions (Rx) Style API
+```rust
+pub trait ChannelExt<T> {
+    fn map<U, F>(self, f: F) -> MappedReceiver<T, U, F> 
+    where F: Fn(T) -> U;
+    
+    fn filter<F>(self, predicate: F) -> FilteredReceiver<T, F>
+    where F: Fn(&T) -> bool;
+    
+    fn take(self, count: usize) -> TakeReceiver<T>;
+    
+    fn skip(self, count: usize) -> SkipReceiver<T>;
+    
+    fn batch(self, size: usize) -> BatchReceiver<T>;
+    
+    fn debounce(self, duration: Duration) -> DebouncedReceiver<T>;
+    
+    fn merge<U>(self, other: Receiver<U>) -> MergedReceiver<T, U>;
+}
+
+// Usage example
+let processed = rx
+    .filter(|msg| msg.priority > Priority::Low)
+    .map(|msg| msg.process())
+    .batch(10)
+    .debounce(Duration::from_millis(100));
+
+go!(move || {
+    while let Ok(batch) = processed.recv() {
+        process_batch(batch);
+    }
+});
+```
+
+### 2.3 Broadcast and Fan-out Patterns
+```rust
+pub mod sync {
+    pub mod broadcast {
+        pub struct BroadcastChannel<T: Clone> {
+            subscribers: RwLock<Vec<WeakSender<T>>>,
+            buffer: RingBuffer<T>,
+            capacity: usize,
+        }
+        
+        impl<T: Clone> BroadcastChannel<T> {
+            pub fn with_capacity(capacity: usize) -> (Broadcaster<T>, BroadcastReceiver<T>) {
+                // All subscribers receive all messages
+            }
+            
+            pub fn subscribe(&self) -> BroadcastReceiver<T> {
+                // Late subscribers can catch up from buffer
+            }
+        }
+    }
+    
+    pub mod fanout {
+        pub struct FanoutChannel<T> {
+            workers: Vec<Sender<T>>,
+            strategy: DistributionStrategy,
+            round_robin_counter: AtomicUsize,
+        }
+        
+        pub enum DistributionStrategy {
+            RoundRobin,
+            LeastLoaded,
+            Hash(fn(&T) -> usize),
+            Random,
+        }
+        
+        impl<T> FanoutChannel<T> {
+            pub fn send(&self, item: T) -> Result<(), SendError<T>> {
+                let worker_idx = match self.strategy {
+                    DistributionStrategy::RoundRobin => {
+                        self.round_robin_counter.fetch_add(1, Ordering::Relaxed) % self.workers.len()
+                    },
+                    DistributionStrategy::LeastLoaded => self.find_least_loaded_worker(),
+                    DistributionStrategy::Hash(hasher) => hasher(&item) % self.workers.len(),
+                    DistributionStrategy::Random => fastrand::usize(0..self.workers.len()),
+                };
+                
+                self.workers[worker_idx].send(item)
+            }
+        }
+    }
+}
+```
+
+## Improvement 3: Performance Optimizations
+
+### 3.1 NUMA-Aware Channel Design
+```rust
+pub mod numa {
+    pub struct NumaChannel<T> {
+        local_queues: Vec<LocalQueue<T>>,
+        global_queue: GlobalQueue<T>,
+        numa_topology: NumaTopology,
+    }
+    
+    impl<T> NumaChannel<T> {
+        pub fn new_numa_aware() -> (Sender<T>, Receiver<T>) {
+            let topology = detect_numa_topology();
+            // Create local queues for each NUMA node
+            // Prefer local queue access, fallback to global
+        }
+        
+        pub fn send_local(&self, item: T) -> Result<(), SendError<T>> {
+            let current_node = get_current_numa_node();
+            if let Some(local_queue) = self.local_queues.get(current_node) {
+                local_queue.try_send(item).or_else(|item| self.global_queue.send(item))
+            } else {
+                self.global_queue.send(item)
+            }
+        }
+    }
+}
+```
+
+### 3.2 Zero-Copy Message Passing
+```rust
+pub mod zero_copy {
+    pub struct ZeroCopyChannel<T> {
+        shared_memory: SharedMemoryRegion<T>,
+        read_cursor: AtomicUsize,
+        write_cursor: AtomicUsize,
+        capacity: usize,
+    }
+    
+    impl<T> ZeroCopyChannel<T> {
+        pub fn send_ref(&self, item: &T) -> Result<(), SendError> 
+        where T: Copy {
+            // Direct memory copy without allocation
+            let write_pos = self.write_cursor.load(Ordering::Acquire);
+            unsafe {
+                ptr::copy_nonoverlapping(
+                    item as *const T,
+                    self.shared_memory.as_mut_ptr().add(write_pos % self.capacity),
+                    1
+                );
+            }
+            self.write_cursor.store(write_pos + 1, Ordering::Release);
+            Ok(())
+        }
+        
+        pub fn recv_ref(&self) -> Result<&T, RecvError> {
+            // Return reference to shared memory, no copy
+            let read_pos = self.read_cursor.load(Ordering::Acquire);
+            let write_pos = self.write_cursor.load(Ordering::Acquire);
+            
+            if read_pos == write_pos {
+                return Err(RecvError::Empty);
+            }
+            
+            let item_ref = unsafe {
+                &*self.shared_memory.as_ptr().add(read_pos % self.capacity)
+            };
+            
+            self.read_cursor.store(read_pos + 1, Ordering::Release);
+            Ok(item_ref)
+        }
+    }
+}
+```
+
+### 3.3 Batched Operations
+```rust
+impl<T> Receiver<T> {
+    pub fn recv_batch(&self, buffer: &mut Vec<T>, max_size: usize) -> Result<usize, RecvError> {
+        let mut count = 0;
+        
+        // Try to fill buffer up to max_size
+        while count < max_size {
+            match self.try_recv() {
+                Ok(item) => {
+                    buffer.push(item);
+                    count += 1;
+                },
+                Err(TryRecvError::Empty) if count > 0 => break, // Got some items
+                Err(TryRecvError::Empty) => {
+                    // Block for at least one item
+                    buffer.push(self.recv()?);
+                    count += 1;
+                },
+                Err(TryRecvError::Disconnected) => {
+                    return if count > 0 { Ok(count) } else { Err(RecvError) };
+                }
+            }
+        }
+        
+        Ok(count)
+    }
+    
+    pub fn recv_batch_timeout(&self, buffer: &mut Vec<T>, max_size: usize, timeout: Duration) 
+        -> Result<usize, RecvTimeoutError> {
+        // Similar to recv_batch but with timeout
+    }
+}
+
+impl<T> Sender<T> {
+    pub fn send_batch(&self, items: &[T]) -> Result<(), SendError<T>> 
+    where T: Clone {
+        // Optimized batch sending
+        for item in items {
+            self.send(item.clone())?;
+        }
+        Ok(())
+    }
+}
+```
+
+## Improvement 4: Enhanced Select Operations
+
+### 4.1 Weighted and Priority Select
+```rust
+#[macro_export]
+macro_rules! select_weighted {
+    (
+        $(weight($w:expr) => $name:pat = $op:expr => $body:expr),+
+    ) => {{
+        // Higher weight = higher probability of selection
+        // Useful for prioritizing certain channels
+    }}
+}
+
+#[macro_export]
+macro_rules! select_priority {
+    (
+        $(priority($p:expr) => $name:pat = $op:expr => $body:expr),+
+    ) => {{
+        // Always check higher priority operations first
+        // Only check lower priority if higher ones are not ready
+    }}
+}
+
+// Usage examples
+let result = select_weighted!(
+    weight(3) => msg = high_priority_rx.recv() => process_high_priority(msg),
+    weight(1) => msg = low_priority_rx.recv() => process_low_priority(msg)
+);
+
+let result = select_priority!(
+    priority(1) => urgent = urgent_rx.recv() => handle_urgent(urgent),
+    priority(2) => normal = normal_rx.recv() => handle_normal(normal),
+    priority(3) => background = background_rx.recv() => handle_background(background)
+);
+```
+
+### 4.2 Conditional and Guarded Select
+```rust
+#[macro_export]
+macro_rules! select_if {
+    (
+        $(if $guard:expr => $name:pat = $op:expr => $body:expr),+
+    ) => {{
+        // Only include operations where guard is true
+    }}
+}
+
+// Usage example
+let can_process_more = queue_size < MAX_QUEUE_SIZE;
+let shutting_down = shutdown_flag.load(Ordering::Relaxed);
+
+select_if!(
+    if can_process_more => work = work_rx.recv() => process_work(work),
+    if !shutting_down => cmd = control_rx.recv() => handle_command(cmd),
+    if true => _ = shutdown_rx.recv() => initiate_shutdown()
+);
+```
+
+## Improvement 5: Monitoring and Debugging
+
+### 5.1 Channel Metrics and Observability
+```rust
+pub struct ChannelMetrics {
+    pub messages_sent: AtomicU64,
+    pub messages_received: AtomicU64,
+    pub messages_dropped: AtomicU64,
+    pub current_queue_size: AtomicUsize,
+    pub max_queue_size: AtomicUsize,
+    pub total_wait_time: AtomicU64, // nanoseconds
+    pub blocked_senders: AtomicUsize,
+    pub blocked_receivers: AtomicUsize,
+}
+
+impl<T> Channel<T> {
+    pub fn metrics(&self) -> &ChannelMetrics {
+        &self.metrics
+    }
+    
+    pub fn reset_metrics(&self) {
+        // Reset all counters to zero
+    }
+    
+    pub fn enable_latency_tracking(&self, enabled: bool) {
+        // Enable/disable detailed latency measurements
+    }
+}
+
+// Integration with monitoring systems
+pub trait MetricsExporter {
+    fn export_metrics(&self, metrics: &ChannelMetrics, channel_name: &str);
+}
+
+pub struct PrometheusExporter;
+impl MetricsExporter for PrometheusExporter {
+    fn export_metrics(&self, metrics: &ChannelMetrics, channel_name: &str) {
+        // Export to Prometheus format
+    }
+}
+```
+
+### 5.2 Debug and Tracing Support
+```rust
+pub struct ChannelDebugger<T> {
+    channel: Channel<T>,
+    message_history: RingBuffer<MessageEvent<T>>,
+    trace_enabled: AtomicBool,
+}
+
+#[derive(Debug)]
+pub enum MessageEvent<T> {
+    Sent { message: T, timestamp: Instant, sender_id: usize },
+    Received { message: T, timestamp: Instant, receiver_id: usize },
+    Dropped { message: T, timestamp: Instant, reason: DropReason },
+}
+
+impl<T: Debug> ChannelDebugger<T> {
+    pub fn trace_message_flow(&self) -> Vec<MessageEvent<T>> {
+        // Return message flow history for debugging
+    }
+    
+    pub fn detect_deadlocks(&self) -> Vec<DeadlockInfo> {
+        // Analyze blocked senders/receivers for potential deadlocks
+    }
+    
+    pub fn analyze_performance(&self) -> PerformanceReport {
+        // Generate performance analysis report
+    }
+}
+```
+
+## Implementation Roadmap
+
+### Phase 1: Core Infrastructure (Month 1-2)
+1. **Enhanced Queue Implementations**
+   - Implement lock-free MPMC with work stealing
+   - Add bounded channel variants
+   - Create priority queue implementation
+
+2. **Builder Pattern API**
+   - Design and implement ChannelBuilder
+   - Add configuration validation
+   - Create comprehensive tests
+
+### Phase 2: Advanced Features (Month 3-4)
+1. **Reactive Extensions**
+   - Implement map, filter, batch operations
+   - Add debounce and throttle operators
+   - Create merge and combine operators
+
+2. **Broadcast and Fan-out**
+   - Implement broadcast channels
+   - Add fan-out distribution strategies
+   - Create subscription management
+
+### Phase 3: Performance Optimization (Month 5-6)
+1. **NUMA Awareness**
+   - Implement NUMA topology detection
+   - Add local queue preferences
+   - Optimize for multi-socket systems
+
+2. **Zero-Copy Operations**
+   - Implement shared memory channels
+   - Add reference-based message passing
+   - Optimize for large message scenarios
+
+### Phase 4: Monitoring and Tooling (Month 7-8)
+1. **Metrics and Observability**
+   - Implement comprehensive metrics collection
+   - Add performance monitoring
+   - Create debugging tools
+
+2. **Integration and Documentation**
+   - Update examples and documentation
+   - Create migration guides
+   - Performance benchmarking
+
+## Benefits and Impact
+
+### Performance Improvements
+- **10-50% throughput increase** through lock-free MPMC and batching
+- **Reduced latency** via priority channels and NUMA awareness
+- **Better memory efficiency** through zero-copy operations
+- **Lower CPU overhead** with optimized select operations
+
+### Developer Experience
+- **Type-safe channel configuration** via builder pattern
+- **Reactive programming support** with familiar operators
+- **Better debugging capabilities** with comprehensive metrics
+- **Easier testing** with deterministic channel behavior
+
+### Ecosystem Benefits
+- **Higher adoption** due to improved performance and usability
+- **Better integration** with monitoring and observability tools
+- **Future-proof design** supporting emerging use cases
+- **Reduced learning curve** with familiar patterns from other ecosystems
+
+## Compatibility Considerations
+
+### Backward Compatibility
+- All existing channel APIs remain unchanged
+- New features are additive, not breaking
+- Migration path provided for deprecated features
+- Performance improvements are transparent
+
+### Integration Challenges
+- Some optimizations may require platform-specific code
+- NUMA awareness needs runtime topology detection
+- Zero-copy channels have stricter type requirements
+- Metrics collection adds small overhead
+
+## Conclusion
+
+The proposed improvements to May's message passing system would significantly enhance both performance and developer experience while maintaining full backward compatibility. The phased implementation approach allows for gradual adoption and validation of each enhancement.
+
+Key benefits include:
+- **Performance**: 10-50% throughput improvements through advanced queue designs
+- **Usability**: Rich API with reactive operators and configuration builders  
+- **Observability**: Comprehensive metrics and debugging capabilities
+- **Scalability**: NUMA-aware and zero-copy optimizations for high-performance scenarios
+
+These improvements would position May as a leading choice for high-performance concurrent applications in Rust, with message passing capabilities that rival or exceed those found in other modern concurrency frameworks. 

--- a/tasks/tasks.md
+++ b/tasks/tasks.md
@@ -1,0 +1,634 @@
+# May Rust Coroutine Library - Implementation PRD
+
+## Executive Summary
+
+This Product Requirements Document (PRD) outlines the comprehensive implementation plan for enhancing the May Rust coroutine library based on three key analysis documents:
+
+1. **AI Usage Guide** - Comprehensive documentation and API reference
+2. **Safety Improvement Analysis** - Eliminating unsafe spawn requirements
+3. **Message Passing Improvements** - Enhanced channel implementations and patterns
+
+The implementation spans **24 months** across **6 major phases**, delivering significant performance improvements (10-50% throughput gains), enhanced safety (90%+ safe API coverage), and superior developer experience through modern patterns and comprehensive tooling.
+
+## 🎯 Project Objectives
+
+### Primary Goals
+- **Eliminate unsafe spawn requirements** through compile-time and runtime safety mechanisms
+- **Improve performance by 10-50%** via advanced channel designs and optimizations
+- **Enhance developer experience** with modern APIs, reactive patterns, and comprehensive tooling
+- **Maintain 100% backward compatibility** throughout the transition
+- **Position May as the leading Rust coroutine library** for high-performance applications
+
+### Success Metrics
+- **Safety**: 90%+ of coroutine spawning operations use safe APIs
+- **Performance**: 10-50% throughput improvement in benchmark scenarios
+- **Adoption**: 25% increase in GitHub stars and crate downloads
+- **Developer Satisfaction**: >4.5/5 rating in community surveys
+- **Ecosystem Integration**: 10+ major projects adopt enhanced May APIs
+
+## 📋 Feature Requirements
+
+## Phase 1: Foundation and Safety Infrastructure (Months 1-4)
+
+### 1.1 Safe Coroutine Spawning APIs
+
+**Priority: Critical**
+**Effort: 8 weeks**
+
+#### Requirements
+- **Compile-time TLS Detection**
+  - Implement proc macro `#[may_coroutine_safe]` to detect `thread_local!` usage
+  - Generate compile errors for unsafe TLS patterns
+  - Provide migration suggestions in error messages
+
+- **Runtime TLS Guards**
+  - Implement `TlsSafe` trait for spawn function parameters
+  - Add runtime TLS access monitoring with thread migration detection
+  - Create `CoroutineSafeSpawner` for verified safe spawning
+
+- **Type-Safe Spawn APIs**
+  - Implement `spawn_safe<F, T>()` function requiring `TlsSafe` bounds
+  - Add `CoroutineSafe` trait for automatic safety verification
+  - Create `SafeBuilder` pattern for coroutine configuration
+
+#### Acceptance Criteria
+- [ ] Compile-time macro detects 95%+ of TLS usage patterns
+- [ ] Runtime guards catch TLS violations with <1% performance overhead
+- [ ] All existing examples compile and run with new safe APIs
+- [ ] Comprehensive test suite covering safety edge cases
+
+### 1.2 Stack Safety Mechanisms
+
+**Priority: Critical**
+**Effort: 6 weeks**
+
+#### Requirements
+- **Stack Guard Pages**
+  - Implement memory protection for stack overflow detection
+  - Add configurable guard page sizes (4KB-16KB)
+  - Provide graceful error handling for stack overflow events
+
+- **Stack Monitoring**
+  - Add runtime stack usage tracking
+  - Implement stack watermark detection
+  - Create stack usage reporting and analytics
+
+- **Enhanced Stack Configuration**
+  - Extend builder pattern with stack safety options
+  - Add automatic stack size estimation based on function complexity
+  - Implement stack size recommendations
+
+#### Acceptance Criteria
+- [ ] Stack guard pages prevent 100% of overflow-related crashes
+- [ ] Stack monitoring adds <2% performance overhead
+- [ ] Automatic stack sizing reduces manual configuration by 80%
+- [ ] Stack safety works across all supported platforms
+
+### 1.3 Enhanced Builder Patterns
+
+**Priority: High**
+**Effort: 4 weeks**
+
+#### Requirements
+- **Safe Coroutine Builder**
+  - Implement fluent API for coroutine configuration
+  - Add compile-time validation of configuration combinations
+  - Provide sensible defaults for all safety options
+
+- **Configuration Validation**
+  - Add runtime validation of configuration parameters
+  - Implement configuration conflict detection
+  - Create helpful error messages for invalid configurations
+
+#### Acceptance Criteria
+- [ ] Builder API covers 100% of coroutine configuration options
+- [ ] Configuration validation catches common mistakes
+- [ ] API is intuitive and requires minimal documentation to use
+
+## Phase 2: Advanced Channel Infrastructure (Months 5-8)
+
+### 2.1 High-Performance Channel Variants
+
+**Priority: Critical**
+**Effort: 10 weeks**
+
+#### Requirements
+- **Lock-Free MPMC with Work Stealing**
+  - Implement per-worker queue design to reduce contention
+  - Add work stealing algorithm for load balancing
+  - Support direct worker targeting for CPU-bound tasks
+  - Achieve 2-5x performance improvement over current MPMC
+
+- **Priority Channel Implementation**
+  - Create multi-level priority queues (4 priority levels)
+  - Implement bitmask optimization for priority checking
+  - Add priority-aware select operations
+  - Ensure strict priority ordering with starvation prevention
+
+- **Bounded Channels with Backpressure**
+  - Implement ring buffer-based bounded channels
+  - Add configurable backpressure strategies (block, drop, error)
+  - Support async/await style operations
+  - Provide timeout operations for all channel types
+
+#### Acceptance Criteria
+- [ ] Lock-free MPMC achieves 2-5x performance improvement
+- [ ] Priority channels maintain strict ordering under load
+- [ ] Bounded channels prevent memory exhaustion in all scenarios
+- [ ] All channel types maintain compatibility with existing select operations
+
+### 2.2 Enhanced API Design
+
+**Priority: High**
+**Effort: 8 weeks**
+
+#### Requirements
+- **Builder Pattern for Channels**
+  - Implement `ChannelBuilder<T>` with fluent configuration API
+  - Support capacity, priority levels, backpressure strategies
+  - Add worker affinity and metrics configuration
+  - Provide type-safe configuration validation
+
+- **Reactive Extensions API**
+  - Implement `map`, `filter`, `batch`, `debounce` operators
+  - Add `take`, `skip`, `merge`, `combine` operations
+  - Support chaining of multiple operators
+  - Maintain zero-cost abstractions where possible
+
+#### Acceptance Criteria
+- [ ] Builder pattern covers all channel configuration options
+- [ ] Reactive operators provide 90% of common use cases
+- [ ] Operator chaining has minimal performance overhead
+- [ ] API is consistent with popular reactive programming libraries
+
+### 2.3 Broadcast and Fan-out Patterns
+
+**Priority: Medium**
+**Effort: 6 weeks**
+
+#### Requirements
+- **Broadcast Channels**
+  - Support multiple subscribers receiving all messages
+  - Implement late subscriber catch-up from buffer
+  - Add subscriber management and cleanup
+  - Support both clone-based and reference-based broadcasting
+
+- **Fan-out Distribution**
+  - Implement round-robin, least-loaded, hash-based, and random distribution
+  - Add dynamic worker addition/removal
+  - Support load balancing metrics and monitoring
+  - Provide fair distribution guarantees
+
+#### Acceptance Criteria
+- [ ] Broadcast channels support 100+ concurrent subscribers
+- [ ] Fan-out distribution achieves even load balancing
+- [ ] Dynamic worker management works without message loss
+- [ ] Performance scales linearly with subscriber count
+
+## Phase 3: Performance Optimizations (Months 9-12)
+
+### 3.1 NUMA-Aware Design
+
+**Priority: Medium**
+**Effort: 8 weeks**
+
+#### Requirements
+- **NUMA Topology Detection**
+  - Implement runtime NUMA topology discovery
+  - Add CPU core to NUMA node mapping
+  - Support both Linux and Windows NUMA APIs
+  - Provide fallback for non-NUMA systems
+
+- **Local Queue Optimization**
+  - Create per-NUMA-node local queues
+  - Implement local-first, global-fallback strategy
+  - Add NUMA-aware worker thread placement
+  - Optimize memory allocation for NUMA locality
+
+#### Acceptance Criteria
+- [ ] NUMA detection works on all supported platforms
+- [ ] Local queue access improves performance by 15-30% on NUMA systems
+- [ ] Graceful degradation on non-NUMA systems
+- [ ] Memory allocation shows improved locality metrics
+
+### 3.2 Zero-Copy Operations
+
+**Priority: Medium**
+**Effort: 6 weeks**
+
+#### Requirements
+- **Shared Memory Channels**
+  - Implement shared memory region management
+  - Add reference-based message passing for large data
+  - Support copy-free operations for `Copy` types
+  - Provide safety guarantees for shared references
+
+- **Optimized Data Structures**
+  - Implement cache-friendly queue layouts
+  - Add bulk operations for improved throughput
+  - Support vectorized operations where possible
+  - Optimize for common message sizes
+
+#### Acceptance Criteria
+- [ ] Zero-copy operations show 20-40% improvement for large messages
+- [ ] Shared memory management is leak-free and safe
+- [ ] Bulk operations improve throughput by 2-3x
+- [ ] Cache-friendly layouts reduce memory bandwidth usage
+
+### 3.3 Batched Operations
+
+**Priority: High**
+**Effort: 4 weeks**
+
+#### Requirements
+- **Batch Send/Receive APIs**
+  - Implement `send_batch()` and `recv_batch()` methods
+  - Add timeout support for batch operations
+  - Support variable batch sizes with adaptive algorithms
+  - Optimize for both latency and throughput scenarios
+
+- **Adaptive Batching**
+  - Implement dynamic batch size adjustment based on load
+  - Add latency-aware batching strategies
+  - Support application-specific batching hints
+  - Provide batching metrics and monitoring
+
+#### Acceptance Criteria
+- [ ] Batch operations improve throughput by 2-5x for high-volume scenarios
+- [ ] Adaptive batching maintains low latency under light load
+- [ ] Batch size optimization works automatically
+- [ ] Batching metrics provide actionable insights
+
+## Phase 4: Enhanced Select and Control Flow (Months 13-16)
+
+### 4.1 Advanced Select Operations
+
+**Priority: High**
+**Effort: 6 weeks**
+
+#### Requirements
+- **Weighted Select**
+  - Implement probability-based channel selection
+  - Support dynamic weight adjustment
+  - Add weight normalization and validation
+  - Ensure fairness over time with weighted randomization
+
+- **Priority Select**
+  - Implement strict priority ordering for select operations
+  - Support dynamic priority changes
+  - Add priority inheritance and inversion handling
+  - Ensure starvation prevention mechanisms
+
+- **Conditional Select**
+  - Add guard expressions for conditional operation inclusion
+  - Support dynamic guard evaluation
+  - Implement efficient guard checking
+  - Provide guard composition and boolean operations
+
+#### Acceptance Criteria
+- [ ] Weighted select maintains specified probability distributions
+- [ ] Priority select ensures strict ordering without starvation
+- [ ] Conditional select adds minimal overhead when guards are false
+- [ ] All select variants integrate seamlessly with existing code
+
+### 4.2 Flow Control Mechanisms
+
+**Priority: Medium**
+**Effort: 4 weeks**
+
+#### Requirements
+- **Backpressure Handling**
+  - Implement configurable backpressure strategies
+  - Add flow control signals and feedback mechanisms
+  - Support rate limiting and throttling
+  - Provide backpressure propagation across channel chains
+
+- **Circuit Breaker Patterns**
+  - Add circuit breaker implementation for fault tolerance
+  - Support configurable failure thresholds and recovery
+  - Implement half-open state for gradual recovery
+  - Provide circuit breaker metrics and monitoring
+
+#### Acceptance Criteria
+- [ ] Backpressure prevents memory exhaustion under load
+- [ ] Circuit breakers provide reliable fault isolation
+- [ ] Flow control maintains system stability
+- [ ] Monitoring provides visibility into flow control states
+
+## Phase 5: Monitoring and Debugging Infrastructure (Months 17-20)
+
+### 5.1 Comprehensive Metrics
+
+**Priority: High**
+**Effort: 8 weeks**
+
+#### Requirements
+- **Channel Metrics**
+  - Implement throughput, latency, and queue size monitoring
+  - Add blocking statistics and contention metrics
+  - Support real-time metrics collection with minimal overhead
+  - Provide metrics aggregation and historical data
+
+- **Coroutine Metrics**
+  - Add coroutine lifecycle tracking (spawn, run, complete, panic)
+  - Implement stack usage monitoring and reporting
+  - Support execution time and yield frequency metrics
+  - Provide coroutine pool utilization statistics
+
+- **System Metrics**
+  - Add worker thread utilization and load balancing metrics
+  - Implement memory usage tracking for coroutines and channels
+  - Support CPU usage attribution to coroutines
+  - Provide system-wide performance dashboards
+
+#### Acceptance Criteria
+- [ ] Metrics collection adds <1% performance overhead
+- [ ] Real-time metrics update within 100ms
+- [ ] Historical data supports trend analysis
+- [ ] Metrics integrate with popular monitoring systems (Prometheus, etc.)
+
+### 5.2 Debug and Tracing Support
+
+**Priority: Medium**
+**Effort: 6 weeks**
+
+#### Requirements
+- **Message Flow Tracing**
+  - Implement message lifecycle tracking across channels
+  - Add distributed tracing support for coroutine communication
+  - Support trace sampling and filtering
+  - Provide trace visualization and analysis tools
+
+- **Deadlock Detection**
+  - Implement runtime deadlock detection algorithms
+  - Add dependency graph analysis for blocked coroutines
+  - Support deadlock prevention and recovery mechanisms
+  - Provide deadlock alerts and reporting
+
+- **Performance Analysis**
+  - Add automated bottleneck detection
+  - Implement performance regression analysis
+  - Support profiling integration (perf, flamegraph)
+  - Provide optimization recommendations
+
+#### Acceptance Criteria
+- [ ] Tracing captures 99%+ of message flows accurately
+- [ ] Deadlock detection identifies issues within 5 seconds
+- [ ] Performance analysis provides actionable insights
+- [ ] Debug tools integrate with standard Rust debugging workflows
+
+## Phase 6: Integration and Ecosystem (Months 21-24)
+
+### 6.1 Development Tools
+
+**Priority: Medium**
+**Effort: 6 weeks**
+
+#### Requirements
+- **May Linter**
+  - Implement cargo plugin for May-specific linting
+  - Add detection of unsafe patterns and anti-patterns
+  - Support automatic fixes for common issues
+  - Provide IDE integration (VS Code, IntelliJ)
+
+- **Safety Monitor**
+  - Create runtime safety monitoring tool
+  - Add continuous safety validation in development
+  - Support safety policy enforcement
+  - Provide safety compliance reporting
+
+- **Benchmarking Suite**
+  - Implement comprehensive performance benchmarks
+  - Add regression testing for performance
+  - Support comparative analysis with other libraries
+  - Provide automated performance reporting
+
+#### Acceptance Criteria
+- [ ] Linter catches 95%+ of common May usage issues
+- [ ] Safety monitor provides real-time feedback
+- [ ] Benchmarks cover all major use cases and patterns
+- [ ] Tools integrate seamlessly with existing Rust workflows
+
+### 6.2 Documentation and Examples
+
+**Priority: High**
+**Effort: 8 weeks**
+
+#### Requirements
+- **Comprehensive Documentation**
+  - Update all API documentation with new features
+  - Add migration guides for unsafe to safe APIs
+  - Create performance tuning guides
+  - Provide troubleshooting and FAQ sections
+
+- **Example Applications**
+  - Create real-world example applications
+  - Add performance comparison examples
+  - Implement common patterns and use cases
+  - Provide best practices documentation
+
+- **Tutorial Series**
+  - Create beginner to advanced tutorial progression
+  - Add video tutorials for complex topics
+  - Implement interactive examples and playground
+  - Provide community contribution guidelines
+
+#### Acceptance Criteria
+- [ ] Documentation covers 100% of public APIs
+- [ ] Examples demonstrate all major features and patterns
+- [ ] Tutorials enable new users to become productive quickly
+- [ ] Community adoption shows measurable improvement
+
+### 6.3 Ecosystem Integration
+
+**Priority: Medium**
+**Effort: 4 weeks**
+
+#### Requirements
+- **Library Integrations**
+  - Create integration guides for popular Rust libraries
+  - Add compatibility layers for async/await ecosystems
+  - Support integration with web frameworks (Actix, Warp, etc.)
+  - Provide database integration examples
+
+- **Monitoring Integrations**
+  - Add Prometheus metrics exporter
+  - Support OpenTelemetry tracing
+  - Integrate with popular APM solutions
+  - Provide custom metrics backends
+
+#### Acceptance Criteria
+- [ ] Integration guides cover top 10 Rust libraries
+- [ ] Monitoring integrations work out-of-the-box
+- [ ] Community reports successful integrations
+- [ ] May becomes recommended choice for high-performance applications
+
+## 🏗️ Technical Architecture
+
+### Safety Infrastructure
+```rust
+// Core safety traits and types
+pub trait TlsSafe: Send + 'static {}
+pub trait CoroutineSafe: TlsSafe + Unpin {}
+
+// Safe spawning APIs
+pub fn spawn_safe<F, T>(f: F) -> JoinHandle<T>
+where
+    F: FnOnce() -> T + CoroutineSafe,
+    T: Send + 'static;
+
+// Builder pattern
+pub struct SafeBuilder {
+    stack_size: Option<usize>,
+    stack_guard_size: Option<usize>,
+    name: Option<String>,
+    tls_check: bool,
+}
+```
+
+### Enhanced Channel Types
+```rust
+// Channel builder
+pub struct ChannelBuilder<T> {
+    capacity: Option<usize>,
+    priority_levels: Option<u8>,
+    backpressure: BackpressureStrategy,
+    metrics: bool,
+}
+
+// Priority channel
+pub struct PriorityChannel<T> {
+    queues: [Queue<T>; 4],
+    priority_mask: AtomicU8,
+    waiters: AtomicOption<Arc<Blocker>>,
+}
+
+// Work-stealing MPMC
+pub struct WorkStealingChannel<T> {
+    local_queues: Vec<LocalQueue<T>>,
+    global_queue: GlobalQueue<T>,
+    workers: AtomicUsize,
+}
+```
+
+### Monitoring Infrastructure
+```rust
+// Metrics collection
+pub struct ChannelMetrics {
+    messages_sent: AtomicU64,
+    messages_received: AtomicU64,
+    current_queue_size: AtomicUsize,
+    total_wait_time: AtomicU64,
+    blocked_senders: AtomicUsize,
+    blocked_receivers: AtomicUsize,
+}
+
+// Tracing support
+pub struct MessageTrace {
+    id: TraceId,
+    timestamp: Instant,
+    sender: CoroutineId,
+    receiver: Option<CoroutineId>,
+    channel: ChannelId,
+}
+```
+
+## 📊 Implementation Timeline
+
+### Phase 1: Foundation (Months 1-4)
+- **Month 1**: TLS detection and runtime guards
+- **Month 2**: Stack safety mechanisms
+- **Month 3**: Safe spawn APIs and builder patterns
+- **Month 4**: Testing, documentation, and integration
+
+### Phase 2: Channels (Months 5-8)
+- **Month 5**: Lock-free MPMC and priority channels
+- **Month 6**: Bounded channels and backpressure
+- **Month 7**: Builder pattern and reactive extensions
+- **Month 8**: Broadcast and fan-out patterns
+
+### Phase 3: Performance (Months 9-12)
+- **Month 9**: NUMA awareness implementation
+- **Month 10**: Zero-copy operations
+- **Month 11**: Batched operations and optimizations
+- **Month 12**: Performance testing and tuning
+
+### Phase 4: Control Flow (Months 13-16)
+- **Month 13**: Advanced select operations
+- **Month 14**: Flow control and backpressure
+- **Month 15**: Circuit breaker patterns
+- **Month 16**: Integration testing and optimization
+
+### Phase 5: Monitoring (Months 17-20)
+- **Month 17**: Metrics infrastructure
+- **Month 18**: Tracing and debugging tools
+- **Month 19**: Performance analysis tools
+- **Month 20**: Monitoring integrations
+
+### Phase 6: Ecosystem (Months 21-24)
+- **Month 21**: Development tools (linter, safety monitor)
+- **Month 22**: Documentation and examples
+- **Month 23**: Ecosystem integrations
+- **Month 24**: Community adoption and final polish
+
+## 🎯 Success Criteria
+
+### Quantitative Metrics
+- **Performance**: 10-50% throughput improvement in benchmark scenarios
+- **Safety**: 90%+ of spawn operations use safe APIs
+- **Adoption**: 25% increase in GitHub stars and crate downloads
+- **Test Coverage**: 95%+ code coverage with comprehensive test suite
+- **Documentation**: 100% API coverage with examples
+
+### Qualitative Metrics
+- **Developer Experience**: >4.5/5 rating in community surveys
+- **Community Feedback**: Positive reception in Rust forums and conferences
+- **Ecosystem Integration**: 10+ major projects adopt enhanced May APIs
+- **Industry Recognition**: May becomes recommended choice for high-performance Rust applications
+
+## 🚨 Risk Mitigation
+
+### Technical Risks
+- **Performance Regression**: Comprehensive benchmarking and performance testing
+- **Compatibility Issues**: Extensive backward compatibility testing
+- **Platform Support**: Multi-platform CI/CD and testing infrastructure
+- **Memory Safety**: Formal verification and extensive fuzzing
+
+### Project Risks
+- **Timeline Delays**: Agile development with regular milestone reviews
+- **Resource Constraints**: Modular implementation allowing for scope adjustment
+- **Community Adoption**: Early preview releases and community engagement
+- **Maintenance Burden**: Comprehensive documentation and contributor guidelines
+
+## 📋 Acceptance Criteria
+
+### Phase Completion Criteria
+Each phase must meet the following criteria before proceeding:
+- [ ] All features implemented and tested
+- [ ] Performance benchmarks meet targets
+- [ ] Documentation complete and reviewed
+- [ ] Community feedback incorporated
+- [ ] Backward compatibility verified
+
+### Final Release Criteria
+- [ ] All phases completed successfully
+- [ ] Performance targets achieved (10-50% improvement)
+- [ ] Safety targets achieved (90%+ safe API usage)
+- [ ] Community adoption metrics met
+- [ ] Production-ready stability demonstrated
+
+## 🔄 Maintenance and Evolution
+
+### Long-term Support
+- **LTS Versions**: Provide 2-year support for major releases
+- **Security Updates**: Monthly security review and patches
+- **Performance Monitoring**: Continuous performance regression testing
+- **Community Support**: Active maintenance of documentation and examples
+
+### Future Roadmap
+- **Async/Await Integration**: Seamless integration with Rust async ecosystem
+- **GPU Coroutines**: Experimental GPU-accelerated coroutine execution
+- **Distributed Coroutines**: Cross-machine coroutine communication
+- **WebAssembly Support**: May coroutines in browser environments
+
+This PRD represents a comprehensive plan to transform May into the leading Rust coroutine library through systematic implementation of safety improvements, performance optimizations, and enhanced developer experience. The 24-month timeline ensures thorough development while maintaining momentum and community engagement. 


### PR DESCRIPTION
# Fix: #124  Map WSAECONNREFUSED (10061) to ConnectionRefused on Windows

**Branch:** `fix/wsa-connrefused-mapping`
**Base:** `master`
**Commits:** 1

## Summary — context

During the **may_minihttp native HTTP client hardening** (PRD: `docs/PRD-http-client-hardening.md`), integration tests for the new `may_minihttp` client were run on a Windows CI matrix. Three tests failed:

- `test_connection_refused`
- `test_connection_timeout`
- `test_connection_close_by_server`

All three assert `io::ErrorKind::ConnectionRefused` after a refused connection. They pass on Linux because Rust's std correctly maps `ECONNREFUSED` (111). On Windows, `may::net::TcpStreamConnect` returns `io::ErrorKind::Uncategorized` for `WSAECONNREFUSED` (10061), so the assertions fail.

This PR fixes the root cause in the `may` crate's Windows I/O layer, which `may_minihttp` depends on for TCP connectivity.

## Root cause

Rust's std library does not map `WSAECONNREFUSED` (10061) to `io::ErrorKind::ConnectionRefused` on Windows — it falls through to `Uncategorized`. The `connect_complete()` wrapper in `may/src/io/sys/windows/miow.rs` passes the raw WSA error up unmodified.

On Linux the epoll-based path uses `SO_ERROR` and Rust's std correctly maps `ECONNREFUSED` (111).

## Changes

| File | Change |
|------|--------|
| `src/io/sys/windows/miow.rs` | Remap WSA 10061 to `ConnectionRefused` in `connect_complete()` (+9 lines) |
| `docs/postmortem_wsaconnrefused.md` | Full postmortem analysis (+104 lines) |

## Testing

The 3 previously-failing may_minihttp integration tests (`test_connection_refused`, `test_connection_timeout`, `test_connection_close_by_server`) now pass on Windows. All 20 client integration tests pass on Linux.

## Prevention

1. Add `map_wsa_errors(io::Error) -> io::Error` helper in the Windows I/O module so other overlapped operations (accept, etc.) don't repeat this gap.
2. CI Windows matrix must cover error-condition tests, not just happy-path connectivity.

## Related

- Upstream fix for may_minihttp: `PR_fix-client-flush-pipelining.md` (missing flush after `write_head_impl` causing pipelining header corruption)
- PRD that discovered both issues: `may_minihttp/docs/PRD-http-client-hardening.md`